### PR TITLE
Add capability to call radiation on physics timestep for first N time steps

### DIFF
--- a/gfsphysics/GFS_layer/GFS_typedefs.meta
+++ b/gfsphysics/GFS_layer/GFS_typedefs.meta
@@ -2025,6 +2025,12 @@
   dimensions = ()
   type = real
   kind = kind_phys
+[nhfrad]
+  standard_name = number_of_timesteps_for_radiation_calls_on_physics_timestep
+  long_name = number of timesteps for radiation calls on physics timestep (coldstarts only)
+  units = count
+  dimensions = ()
+  type = integer
 [levr]
   standard_name = number_of_vertical_layers_for_radiation_calculations
   long_name = number of vertical levels for radiation calculations


### PR DESCRIPTION
This PR adds the new variable `nhfrad` (number of high frequency radiation calls) to `GFS_typedefs.*`, required for calling the radiation on physics timestep for first `nhfrad` timesteps (coldstart only, for spinup). The new functionality is activated by setting `nhfrad` in the GFS physics namelist section to a value larger than one (default is zero).

Associated PR: https://github.com/NOAA-GSD/ccpp-physics/pull/1

This PR has been tested to work on macOS/GNU and on hera/intel (full regression tests against official baseline using rt.conf, manual compilation and test with GSD physics).