### PR TITLE
Delay CCPP initialization, updates for Thompson MP initialization

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,5 @@
 	branch = gsd/develop
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/climbfuji/ccpp-physics
-	branch = thompson_init_update
+	url = https://github.com/noaa-gsd/ccpp-physics
+	branch = gsd/develop

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,5 @@
 	branch = gsd/develop
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/noaa-gsd/ccpp-physics
-	branch = gsd/develop
+	url = https://github.com/climbfuji/ccpp-physics
+	branch = thompson_init_update

--- a/ccpp/config/ccpp_prebuild_config.py
+++ b/ccpp/config/ccpp_prebuild_config.py
@@ -304,10 +304,14 @@ OPTIONAL_ARGUMENTS = {
         },
     'mp_thompson' : {
         'mp_thompson_init' : [
+            'cloud_droplet_number_concentration',
             'water_friendly_aerosol_number_concentration',
             'ice_friendly_aerosol_number_concentration',
             'tendency_of_water_friendly_aerosols_at_surface',
             'tendency_of_ice_friendly_aerosols_at_surface',
+            'mean_effective_radius_for_liquid_cloud',
+            'mean_effective_radius_for_ice_cloud',
+            'mean_effective_radius_for_snow_flake',
             ],
         'mp_thompson_run' : [
             'cloud_droplet_number_concentration_updated_by_physics',
@@ -318,15 +322,6 @@ OPTIONAL_ARGUMENTS = {
             'mean_effective_radius_for_liquid_cloud',
             'mean_effective_radius_for_ice_cloud',
             'mean_effective_radius_for_snow_flake',
-            ],
-        },
-    'mp_thompson_pre' : {
-        'mp_thompson_pre_run' : [
-            'cloud_droplet_number_concentration_updated_by_physics',
-            'water_friendly_aerosol_number_concentration_updated_by_physics',
-            'ice_friendly_aerosol_number_concentration_updated_by_physics',
-            'tendency_of_water_friendly_aerosols_at_surface',
-            'tendency_of_ice_friendly_aerosols_at_surface',
             ],
         },
     'mp_fer_hires' : {


### PR DESCRIPTION
This PR
- moves the CCPP initialization to the latest possible point during the model run, so that all coldstart/restart data is available for initializing physics
- updates the submodule pointer and .gitmodules (temporarily for code review) for PR https://github.com/NOAA-GSD/ccpp-physics/pull/4