### PR TITLE
Bug fixes for/update of "Changes in cloud/radiation interaction in GSD physics suite", bug fixes for non-aerosol-aware Thompson MP

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,5 @@
 	branch = gsd/develop
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/NOAA-GSD/ccpp-physics
-	branch = gsd/develop
+	url = https://github.com/climbfuji/ccpp-physics
+	branch = gsd-dev-clouds_thompson-no-aero_dom

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,5 @@
 	branch = gsd/develop
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/climbfuji/ccpp-physics
-	branch = gsd-dev-clouds_thompson-no-aero_dom
+	url = https://github.com/NOAA-GSD/ccpp-physics
+	branch = gsd/develop

--- a/ccpp/config/ccpp_prebuild_config.py
+++ b/ccpp/config/ccpp_prebuild_config.py
@@ -207,8 +207,6 @@ SCHEME_FILES = {
     'FV3/ccpp/physics/physics/ysuvdif.F90'                       : [ 'slow_physics' ],
     'FV3/ccpp/physics/physics/module_MYNNPBL_wrapper.F90'        : [ 'slow_physics' ],
     'FV3/ccpp/physics/physics/module_MYNNSFC_wrapper.F90'        : [ 'slow_physics' ],
-    'FV3/ccpp/physics/physics/module_MYNNrad_pre.F90'            : [ 'slow_physics' ],
-    'FV3/ccpp/physics/physics/module_MYNNrad_post.F90'           : [ 'slow_physics' ],
     'FV3/ccpp/physics/physics/module_SGSCloud_RadPre.F90'        : [ 'slow_physics' ],
     'FV3/ccpp/physics/physics/module_SGSCloud_RadPost.F90'       : [ 'slow_physics' ],
     'FV3/ccpp/physics/physics/module_MYJSFC_wrapper.F90'         : [ 'slow_physics' ],

--- a/ccpp/config/ccpp_prebuild_config.py
+++ b/ccpp/config/ccpp_prebuild_config.py
@@ -209,6 +209,8 @@ SCHEME_FILES = {
     'FV3/ccpp/physics/physics/module_MYNNSFC_wrapper.F90'        : [ 'slow_physics' ],
     'FV3/ccpp/physics/physics/module_MYNNrad_pre.F90'            : [ 'slow_physics' ],
     'FV3/ccpp/physics/physics/module_MYNNrad_post.F90'           : [ 'slow_physics' ],
+    'FV3/ccpp/physics/physics/module_SGSCloud_RadPre.F90'        : [ 'slow_physics' ],
+    'FV3/ccpp/physics/physics/module_SGSCloud_RadPost.F90'       : [ 'slow_physics' ],
     'FV3/ccpp/physics/physics/module_MYJSFC_wrapper.F90'         : [ 'slow_physics' ],
     'FV3/ccpp/physics/physics/module_MYJPBL_wrapper.F90'         : [ 'slow_physics' ],
     'FV3/ccpp/physics/physics/mp_thompson_pre.F90'               : [ 'slow_physics' ],

--- a/ccpp/suites/suite_FV3_GFS_v15_mynn.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15_mynn.xml
@@ -18,9 +18,9 @@
   <group name="radiation">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_rad_reset</scheme>
+      <scheme>mynnrad_pre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>rrtmg_sw_pre</scheme>
-      <scheme>mynnrad_pre</scheme>
       <scheme>rrtmg_sw</scheme>
       <scheme>rrtmg_sw_post</scheme>
       <scheme>rrtmg_lw_pre</scheme>

--- a/ccpp/suites/suite_FV3_GFS_v15_mynn.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15_mynn.xml
@@ -18,14 +18,14 @@
   <group name="radiation">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_rad_reset</scheme>
-      <scheme>mynnrad_pre</scheme>
+      <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>rrtmg_sw_pre</scheme>
       <scheme>rrtmg_sw</scheme>
       <scheme>rrtmg_sw_post</scheme>
       <scheme>rrtmg_lw_pre</scheme>
       <scheme>rrtmg_lw</scheme>
-      <scheme>mynnrad_post</scheme>
+      <scheme>sgscloud_radpre</scheme>
       <scheme>rrtmg_lw_post</scheme>
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>

--- a/ccpp/suites/suite_FV3_GFS_v15_thompson_mynn.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15_thompson_mynn.xml
@@ -13,14 +13,14 @@
   <group name="radiation">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_rad_reset</scheme>
+      <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>rrtmg_sw_pre</scheme>
-      <scheme>mynnrad_pre</scheme>
       <scheme>rrtmg_sw</scheme>
       <scheme>rrtmg_sw_post</scheme>
       <scheme>rrtmg_lw_pre</scheme>
       <scheme>rrtmg_lw</scheme>
-      <scheme>mynnrad_post</scheme>
+      <scheme>sgscloud_radpre</scheme>
       <scheme>rrtmg_lw_post</scheme>
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>

--- a/ccpp/suites/suite_FV3_GSD_SAR.xml
+++ b/ccpp/suites/suite_FV3_GSD_SAR.xml
@@ -13,14 +13,14 @@
   <group name="radiation">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_rad_reset</scheme>
+      <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>rrtmg_sw_pre</scheme>
-      <scheme>mynnrad_pre</scheme>
       <scheme>rrtmg_sw</scheme>
       <scheme>rrtmg_sw_post</scheme>
       <scheme>rrtmg_lw_pre</scheme>
       <scheme>rrtmg_lw</scheme>
-      <scheme>mynnrad_post</scheme>
+      <scheme>sgscloud_radpre</scheme>
       <scheme>rrtmg_lw_post</scheme>
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>

--- a/ccpp/suites/suite_FV3_GSD_noah.xml
+++ b/ccpp/suites/suite_FV3_GSD_noah.xml
@@ -13,14 +13,14 @@
   <group name="radiation">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_rad_reset</scheme>
+      <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>rrtmg_sw_pre</scheme>
-      <scheme>mynnrad_pre</scheme>
       <scheme>rrtmg_sw</scheme>
       <scheme>rrtmg_sw_post</scheme>
       <scheme>rrtmg_lw_pre</scheme>
       <scheme>rrtmg_lw</scheme>
-      <scheme>mynnrad_post</scheme>
+      <scheme>sgscloud_radpost</scheme>
       <scheme>rrtmg_lw_post</scheme>
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>

--- a/ccpp/suites/suite_FV3_GSD_v0.xml
+++ b/ccpp/suites/suite_FV3_GSD_v0.xml
@@ -13,14 +13,14 @@
   <group name="radiation">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_rad_reset</scheme>
+      <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>rrtmg_sw_pre</scheme>
-      <scheme>mynnrad_pre</scheme>
       <scheme>rrtmg_sw</scheme>
       <scheme>rrtmg_sw_post</scheme>
       <scheme>rrtmg_lw_pre</scheme>
       <scheme>rrtmg_lw</scheme>
-      <scheme>mynnrad_post</scheme>
+      <scheme>sgscloud_radpre</scheme>
       <scheme>rrtmg_lw_post</scheme>
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>

--- a/ccpp/suites/suite_FV3_GSD_v0_drag_suite.xml
+++ b/ccpp/suites/suite_FV3_GSD_v0_drag_suite.xml
@@ -13,14 +13,14 @@
   <group name="radiation">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_rad_reset</scheme>
+      <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>rrtmg_sw_pre</scheme>
-      <scheme>mynnrad_pre</scheme>
       <scheme>rrtmg_sw</scheme>
       <scheme>rrtmg_sw_post</scheme>
       <scheme>rrtmg_lw_pre</scheme>
       <scheme>rrtmg_lw</scheme>
-      <scheme>mynnrad_post</scheme>
+      <scheme>sgscloud_radpre</scheme>
       <scheme>rrtmg_lw_post</scheme>
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>

--- a/gfsphysics/GFS_layer/GFS_restart.F90
+++ b/gfsphysics/GFS_layer/GFS_restart.F90
@@ -123,7 +123,7 @@ module GFS_restart
 #ifdef CCPP
     ! GF
     if (Model%imfdeepcnv == 3) then
-      Restart%num3d = Restart%num3d + 2
+      Restart%num3d = Restart%num3d + 3
     endif
     ! MYNN PBL 
     if (Model%do_mynnedmf) then

--- a/gfsphysics/GFS_layer/GFS_restart.F90
+++ b/gfsphysics/GFS_layer/GFS_restart.F90
@@ -188,7 +188,7 @@ module GFS_restart
     !--- RAP/HRRR-specific variables, 2D
     num = offset + ndiag_rst
     ! GF
-    if (Model%imfdeepcnv == 3) then
+    if (Model%imfdeepcnv == Model%imfdeepcnv_gf) then
       num = num + 1
       Restart%name2d(num) = 'gf_2d_conv_act'
       do nb = 1,nblks
@@ -267,7 +267,7 @@ module GFS_restart
     num = Model%ntot3d
 
     ! GF
-    if (Model%imfdeepcnv == 3) then
+    if (Model%imfdeepcnv == Model%imfdeepcnv_gf) then
       num = num + 1
       Restart%name3d(num) = 'gf_3d_prevst'
       do nb = 1,nblks
@@ -277,6 +277,11 @@ module GFS_restart
       Restart%name3d(num) = 'gf_3d_prevsq'
       do nb = 1,nblks
         Restart%data(nb,num)%var3p => Tbd(nb)%prevsq(:,:)
+      enddo
+      num = num + 1
+      Restart%name3d(num) = 'gf_3d_qci_conv'
+      do nb = 1,nblks
+        Restart%data(nb,num)%var3p => Coupling(nb)%qci_conv(:,:)
       enddo
     endif
     ! MYNN PBL

--- a/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -2634,6 +2634,7 @@ module GFS_typedefs
       Coupling%nwfa2d   = clear_val
       Coupling%nifa2d   = clear_val
     endif
+
 #ifdef CCPP
     if (Model%imfdeepcnv == Model%imfdeepcnv_gf) then
       allocate (Coupling%qci_conv (IM,Model%levs))
@@ -6072,9 +6073,9 @@ module GFS_typedefs
 
     if (Model%imp_physics == Model%imp_physics_thompson) then
       if (Model%ltaerosol) then
-        Interstitial%nvdiff = 10
+        Interstitial%nvdiff = 12
       else
-        Interstitial%nvdiff = 7
+        Interstitial%nvdiff = 9
       endif
       if (Model%satmedmf) Interstitial%nvdiff = Interstitial%nvdiff + 1
       Interstitial%nncl = 5

--- a/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -497,6 +497,8 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: dqdti   (:,:)   => null()  !< instantaneous total moisture tendency (kg/kg/s)
     real (kind=kind_phys), pointer :: ushfsfci(:)     => null()  !< instantaneous upward sensible heat flux (w/m**2)
     real (kind=kind_phys), pointer :: dkt     (:,:)   => null()  !< instantaneous dkt diffusion coefficient for temperature (m**2/s)
+    real (kind=kind_phys), pointer :: qci_conv(:,:)   => null()  !< convective cloud condesate after rainout
+
 
     contains
       procedure :: create  => coupling_create  !<   allocate array data
@@ -2606,6 +2608,12 @@ module GFS_typedefs
       Coupling%nwfa2d   = clear_val
       Coupling%nifa2d   = clear_val
     endif
+#ifdef CCPP
+    if (Model%imfdeepcnv == Model%imfdeepcnv_gf) then
+      allocate (Coupling%qci_conv (IM,Model%levs))
+      Coupling%qci_conv   = clear_val
+    endif
+#endif
 
   end subroutine coupling_create
 

--- a/gfsphysics/GFS_layer/GFS_typedefs.meta
+++ b/gfsphysics/GFS_layer/GFS_typedefs.meta
@@ -1792,7 +1792,13 @@
   dimensions = (horizontal_dimension,vertical_dimension)
   type = real
   kind = kind_phys
-
+[qci_conv]
+  standard_name = convective_cloud_condesate_after_rainout
+  long_name = convective cloud condesate after rainout
+  units = kg kg-1
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
 ########################################################################
 [ccpp-arg-table]
   name = GFS_control_type


### PR DESCRIPTION
This PR:

- contains the original PR from @tanyasmirnova for "Changes to the cloud/radiation interaction with GSD physics suite using Thompson MP, MYNN PBL and GF convective scheme", #10 
- adjusts the number of tracers in the array of diffused tracers for Thompson MP (fixes https://github.com/NOAA-GSD/ccpp-physics/issues/10)
- replaces `mynnrad_{pre,post}` with `sgscloud_{pre,post}` in all suites that use it, remove `mynnrad_{pre,post}` from CCPP prebuild config

Associated PRs:
https://github.com/NOAA-GSD/ccpp-physics/pull/16
https://github.com/NOAA-GSD/fv3atm/pull/13
https://github.com/NOAA-GSD/ufs-weather-model/pull/11

See https://github.com/NOAA-GSD/ufs-weather-model/pull/11 for regression testing information.