### PR TITLE
Mynnsfclay from joe in latest code without reversing composites in typedefs 2020/03/19

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,5 +10,7 @@
 	path = ccpp/physics
 	#url = https://github.com/NOAA-GSD/ccpp-physics
 	#branch = gsd/develop
-	url = https://github.com/climbfuji/ccpp-physics
-	branch = mynnsfclay_from_joe_in_latest_code
+	#url = https://github.com/climbfuji/ccpp-physics
+	#branch = mynnsfclay_from_joe_in_latest_code
+	url = https://github.com/NOAA-GSD/ccpp-physics
+	branch = mynnsfclay_from_joe_in_latest_code_without_reversing_composites_in_typedefs_20200319

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,7 @@
 	branch = gsd/develop
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/NOAA-GSD/ccpp-physics
-	branch = gsd/develop
+	#url = https://github.com/NOAA-GSD/ccpp-physics
+	#branch = gsd/develop
+	url = https://github.com/climbfuji/ccpp-physics
+	branch = mynnsfclay_from_joe_in_latest_code

--- a/atmos_model.F90
+++ b/atmos_model.F90
@@ -1443,7 +1443,7 @@ subroutine update_atmos_chemistry(state, rc)
           ib = i + Atm_block%isc - 1
           nb = Atm_block%blkno(ib,jb)
           ix = Atm_block%ixp(ib,jb)
-          hpbl(i,j)   = IPD_Data(nb)%IntDiag%hpbl(ix)
+          hpbl(i,j)   = IPD_Data(nb)%Tbd%hpbl(ix)
           area(i,j)   = IPD_Data(nb)%Grid%area(ix)
           stype(i,j)  = IPD_Data(nb)%Sfcprop%stype(ix)
           rainc(i,j)  = IPD_Data(nb)%Coupling%rainc_cpl(ix)

--- a/gfsphysics/GFS_layer/GFS_diagnostics.F90
+++ b/gfsphysics/GFS_layer/GFS_diagnostics.F90
@@ -1535,7 +1535,7 @@ module GFS_diagnostics
     ExtDiag(idx)%intpl_method = 'bilinear'
     allocate (ExtDiag(idx)%data(nblks))
     do nb = 1,nblks
-      ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%hpbl(:)
+      ExtDiag(idx)%data(nb)%var2 => Tbd(nb)%hpbl(:)
     enddo
 
     idx = idx + 1

--- a/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -259,6 +259,27 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: oro    (:)   => null()  !< orography 
     real (kind=kind_phys), pointer :: oro_uf (:)   => null()  !< unfiltered orography
 
+    real (kind=kind_phys), pointer :: qss_ice(:)       => null()  !<
+    real (kind=kind_phys), pointer :: qss_land(:)      => null()  !<
+    real (kind=kind_phys), pointer :: qss_ocean(:)     => null()  !<
+    real (kind=kind_phys), pointer :: snowd_ice(:)     => null()  !<
+    real (kind=kind_phys), pointer :: snowd_land(:)    => null()  !<
+    real (kind=kind_phys), pointer :: snowd_ocean(:)    => null() !<
+    real (kind=kind_phys), pointer :: tsfc_ice(:)      => null()  !<
+    real (kind=kind_phys), pointer :: tsfc_land(:)     => null()  !<
+    real (kind=kind_phys), pointer :: tsfc_ocean(:)    => null()  !<
+    real (kind=kind_phys), pointer :: tsurf_ice(:)     => null()  !<
+    real (kind=kind_phys), pointer :: tsurf_land(:)    => null()  !<
+    real (kind=kind_phys), pointer :: tsurf_ocean(:)   => null()  !<
+    real (kind=kind_phys), pointer :: uustar_ice(:)    => null()  !<
+    real (kind=kind_phys), pointer :: uustar_land(:)   => null()  !<
+    real (kind=kind_phys), pointer :: uustar_ocean(:)  => null()  !<
+    real (kind=kind_phys), pointer :: zorl_ice(:)      => null()  !<
+    real (kind=kind_phys), pointer :: zorl_land(:)     => null()  !<
+    real (kind=kind_phys), pointer :: zorl_ocean(:)    => null()  !<
+    real (kind=kind_phys), pointer :: evap(:)          => null()  !<
+    real (kind=kind_phys), pointer :: hflx(:)          => null()  !<
+
 !-- In/Out
 #ifdef CCPP
     real (kind=kind_phys), pointer :: conv_act(:)  => null()  !< convective activity counter hli 09/2017
@@ -1191,6 +1212,9 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: phy_f2d  (:,:)   => null()  !< 2d arrays saved for restart
     real (kind=kind_phys), pointer :: phy_f3d  (:,:,:) => null()  !< 3d arrays saved for restart
 
+!--- Diagnostic that needs to be carried over to the next time step (removed from diag_type)
+    real (kind=kind_phys), pointer :: hpbl     (:)     => null()  !< Planetary boundary layer height
+
 #ifndef CCPP
 !--- for explicit data blocking
     integer                        :: blkno                       !< block number of this block
@@ -1415,7 +1439,6 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: dpt2m  (:)     => null()   !< 2 meter dew point temperature
     real (kind=kind_phys), pointer :: zlvl   (:)     => null()   !< layer 1 height (m)
     real (kind=kind_phys), pointer :: psurf  (:)     => null()   !< surface pressure (Pa)
-    real (kind=kind_phys), pointer :: hpbl   (:)     => null()   !< pbl height (m)
     real (kind=kind_phys), pointer :: pwat   (:)     => null()   !< precipitable water
     real (kind=kind_phys), pointer :: t1     (:)     => null()   !< layer 1 temperature (K)
     real (kind=kind_phys), pointer :: q1     (:)     => null()   !< layer 1 specific humidity (kg/kg)
@@ -1665,7 +1688,6 @@ module GFS_typedefs
     real (kind=kind_phys), pointer      :: ep1d_ice(:)        => null()  !<
     real (kind=kind_phys), pointer      :: ep1d_land(:)       => null()  !<
     real (kind=kind_phys), pointer      :: ep1d_ocean(:)      => null()  !<
-    real (kind=kind_phys), pointer      :: evap(:)            => null()  !<
     real (kind=kind_phys), pointer      :: evap_ice(:)        => null()  !<
     real (kind=kind_phys), pointer      :: evap_land(:)       => null()  !<
     real (kind=kind_phys), pointer      :: evap_ocean(:)      => null()  !<
@@ -1711,7 +1733,6 @@ module GFS_typedefs
     real (kind=kind_phys), pointer      :: gwdcv(:,:)         => null()  !<
     integer                             :: h2o_coeff                     !<
     real (kind=kind_phys), pointer      :: h2o_pres(:)        => null()  !<
-    real (kind=kind_phys), pointer      :: hflx(:)            => null()  !<
     real (kind=kind_phys), pointer      :: hflx_ice(:)        => null()  !<
     real (kind=kind_phys), pointer      :: hflx_land(:)       => null()  !<
     real (kind=kind_phys), pointer      :: hflx_ocean(:)      => null()  !<
@@ -1783,9 +1804,6 @@ module GFS_typedefs
     real (kind=kind_phys), pointer      :: qrn(:,:)           => null()  !<
     real (kind=kind_phys), pointer      :: qsnw(:,:)          => null()  !<
     real (kind=kind_phys), pointer      :: qss(:)             => null()  !<
-    real (kind=kind_phys), pointer      :: qss_ice(:)         => null()  !<
-    real (kind=kind_phys), pointer      :: qss_land(:)        => null()  !<
-    real (kind=kind_phys), pointer      :: qss_ocean(:)       => null()  !<
     real (kind=kind_phys)               :: raddt                         !<
     real (kind=kind_phys), pointer      :: rainmp(:)          => null()  !<
     real (kind=kind_phys), pointer      :: raincd(:)          => null()  !<
@@ -1817,9 +1835,6 @@ module GFS_typedefs
     logical                             :: skip_macro                    !<
     integer, pointer                    :: slopetype(:)       => null()  !<
     real (kind=kind_phys), pointer      :: snowc(:)           => null()  !<
-    real (kind=kind_phys), pointer      :: snowd_ice(:)       => null()  !<
-    real (kind=kind_phys), pointer      :: snowd_land(:)      => null()  !<
-    real (kind=kind_phys), pointer      :: snowd_ocean(:)     => null()  !<
     real (kind=kind_phys), pointer      :: snohf(:)           => null()  !<
     real (kind=kind_phys), pointer      :: snowmp(:)          => null()  !<
     real (kind=kind_phys), pointer      :: snowmt(:)          => null()  !<
@@ -1843,24 +1858,15 @@ module GFS_typedefs
     real (kind=kind_phys), pointer      :: trans(:)           => null()  !<
     real (kind=kind_phys), pointer      :: tseal(:)           => null()  !<
     real (kind=kind_phys), pointer      :: tsfa(:)            => null()  !<
-    real (kind=kind_phys), pointer      :: tsfc_ice(:)        => null()  !<
-    real (kind=kind_phys), pointer      :: tsfc_land(:)       => null()  !<
-    real (kind=kind_phys), pointer      :: tsfc_ocean(:)      => null()  !<
     real (kind=kind_phys), pointer      :: tsfg(:)            => null()  !<
     real (kind=kind_phys), pointer      :: tsnow(:)           => null()  !<
     real (kind=kind_phys), pointer      :: tsurf(:)           => null()  !<
-    real (kind=kind_phys), pointer      :: tsurf_ice(:)       => null()  !<
-    real (kind=kind_phys), pointer      :: tsurf_land(:)      => null()  !<
-    real (kind=kind_phys), pointer      :: tsurf_ocean(:)     => null()  !<
     real (kind=kind_phys), pointer      :: ud_mf(:,:)         => null()  !<
     real (kind=kind_phys), pointer      :: ulwsfc_cice(:)     => null()  !<
     real (kind=kind_phys), pointer      :: dusfc_cice(:)      => null()  !<
     real (kind=kind_phys), pointer      :: dvsfc_cice(:)      => null()  !<
     real (kind=kind_phys), pointer      :: dqsfc_cice(:)      => null()  !<
     real (kind=kind_phys), pointer      :: dtsfc_cice(:)      => null()  !<
-    real (kind=kind_phys), pointer      :: uustar_ice(:)      => null()  !<
-    real (kind=kind_phys), pointer      :: uustar_land(:)     => null()  !<
-    real (kind=kind_phys), pointer      :: uustar_ocean(:)    => null()  !<
     real (kind=kind_phys), pointer      :: vdftra(:,:,:)      => null()  !<
     real (kind=kind_phys), pointer      :: vegf1d(:)          => null()  !<
     integer, pointer                    :: vegtype(:)         => null()  !<
@@ -1877,9 +1883,6 @@ module GFS_typedefs
     real (kind=kind_phys), pointer      :: xlai1d(:)          => null()  !<
     real (kind=kind_phys), pointer      :: xmu(:)             => null()  !<
     real (kind=kind_phys), pointer      :: z01d(:)            => null()  !<
-    real (kind=kind_phys), pointer      :: zorl_ice(:)        => null()  !<
-    real (kind=kind_phys), pointer      :: zorl_land(:)       => null()  !<
-    real (kind=kind_phys), pointer      :: zorl_ocean(:)      => null()  !<
     real (kind=kind_phys), pointer      :: zt1d(:)            => null()  !<
     real (kind=kind_phys), pointer      :: gw_dudt(:,:)       => null()  !<
     real (kind=kind_phys), pointer      :: gw_dvdt(:,:)       => null()  !<
@@ -2131,6 +2134,48 @@ module GFS_typedefs
     Sfcprop%uustar  = clear_val
     Sfcprop%oro     = clear_val
     Sfcprop%oro_uf  = clear_val
+
+    allocate (Sfcprop%qss_ice     (IM))
+    allocate (Sfcprop%qss_land    (IM))
+    allocate (Sfcprop%qss_ocean   (IM))
+    allocate (Sfcprop%snowd_ice   (IM))
+    allocate (Sfcprop%snowd_land  (IM))
+    allocate (Sfcprop%snowd_ocean (IM))
+    allocate (Sfcprop%tsfc_ice    (IM))
+    allocate (Sfcprop%tsfc_land   (IM))
+    allocate (Sfcprop%tsfc_ocean  (IM))
+    allocate (Sfcprop%tsurf_ice   (IM))
+    allocate (Sfcprop%tsurf_land  (IM))
+    allocate (Sfcprop%tsurf_ocean (IM))
+    allocate (Sfcprop%uustar_ice  (IM))
+    allocate (Sfcprop%uustar_land (IM))
+    allocate (Sfcprop%uustar_ocean(IM))
+    allocate (Sfcprop%zorl_ice    (IM))
+    allocate (Sfcprop%zorl_land   (IM))
+    allocate (Sfcprop%zorl_ocean  (IM))
+    allocate (Sfcprop%evap        (IM))
+    allocate (Sfcprop%hflx        (IM))
+
+    Sfcprop%qss_ice       = huge
+    Sfcprop%qss_land      = huge
+    Sfcprop%qss_ocean     = huge
+    Sfcprop%snowd_ice     = huge
+    Sfcprop%snowd_land    = huge
+    Sfcprop%snowd_ocean   = huge
+    Sfcprop%tsfc_ice      = huge
+    Sfcprop%tsfc_land     = huge
+    Sfcprop%tsfc_ocean    = huge
+    Sfcprop%tsurf_ice     = huge
+    Sfcprop%tsurf_land    = huge
+    Sfcprop%tsurf_ocean   = huge
+    Sfcprop%uustar_ice    = huge
+    Sfcprop%uustar_land   = huge
+    Sfcprop%uustar_ocean  = huge
+    Sfcprop%zorl_ice      = huge
+    Sfcprop%zorl_land     = huge
+    Sfcprop%zorl_ocean    = huge
+    Sfcprop%evap          = clear_val
+    Sfcprop%hflx          = clear_val
 
 !--- In/Out
     allocate (Sfcprop%hice   (IM))
@@ -4898,6 +4943,9 @@ module GFS_typedefs
 !   if (Model%do_shoc) Tbd%phy_f3d(:,1,Model%ntot3d-1) = 3.0
 !   if (Model%do_shoc) Tbd%phy_f3d(:,:,Model%ntot3d-1) = 1.0
 
+    allocate (Tbd%hpbl (IM))
+    Tbd%hpbl     = clear_val
+
 #ifndef CCPP
     Tbd%blkno = BLKNO
 #endif
@@ -5133,7 +5181,6 @@ module GFS_typedefs
     allocate (Diag%dpt2m   (IM))
     allocate (Diag%zlvl    (IM))
     allocate (Diag%psurf   (IM))
-    allocate (Diag%hpbl    (IM))
     allocate (Diag%pwat    (IM))
     allocate (Diag%t1      (IM))
     allocate (Diag%q1      (IM))
@@ -5433,7 +5480,6 @@ module GFS_typedefs
     Diag%dpt2m      = zero
     Diag%zlvl       = zero
     Diag%psurf      = zero
-    Diag%hpbl       = zero
     Diag%pwat       = zero
     Diag%t1         = zero
     Diag%q1         = zero
@@ -5775,7 +5821,6 @@ module GFS_typedefs
     allocate (Interstitial%ep1d_ice        (IM))
     allocate (Interstitial%ep1d_land       (IM))
     allocate (Interstitial%ep1d_ocean      (IM))
-    allocate (Interstitial%evap            (IM))
     allocate (Interstitial%evap_ice        (IM))
     allocate (Interstitial%evap_land       (IM))
     allocate (Interstitial%evap_ocean      (IM))
@@ -5818,7 +5863,6 @@ module GFS_typedefs
     allocate (Interstitial%gwdcu           (IM,Model%levs))
     allocate (Interstitial%gwdcv           (IM,Model%levs))
     allocate (Interstitial%h2o_pres        (levh2o))
-    allocate (Interstitial%hflx            (IM))
     allocate (Interstitial%hflx_ice        (IM))
     allocate (Interstitial%hflx_land       (IM))
     allocate (Interstitial%hflx_ocean      (IM))
@@ -5847,9 +5891,6 @@ module GFS_typedefs
     allocate (Interstitial%qlyr            (IM,Model%levr+LTP))
     allocate (Interstitial%prcpmp          (IM))
     allocate (Interstitial%qss             (IM))
-    allocate (Interstitial%qss_ice         (IM))
-    allocate (Interstitial%qss_land        (IM))
-    allocate (Interstitial%qss_ocean       (IM))
     allocate (Interstitial%raincd          (IM))
     allocate (Interstitial%raincs          (IM))
     allocate (Interstitial%rainmcadj       (IM))
@@ -5877,9 +5918,6 @@ module GFS_typedefs
     allocate (Interstitial%sigmatot        (IM,Model%levs))
     allocate (Interstitial%slopetype       (IM))
     allocate (Interstitial%snowc           (IM))
-    allocate (Interstitial%snowd_ice       (IM))
-    allocate (Interstitial%snowd_land      (IM))
-    allocate (Interstitial%snowd_ocean     (IM))
     allocate (Interstitial%snohf           (IM))
     allocate (Interstitial%snowmt          (IM))
     allocate (Interstitial%soiltype        (IM))
@@ -5897,23 +5935,14 @@ module GFS_typedefs
     allocate (Interstitial%trans           (IM))
     allocate (Interstitial%tseal           (IM))
     allocate (Interstitial%tsfa            (IM))
-    allocate (Interstitial%tsfc_ice        (IM))
-    allocate (Interstitial%tsfc_land       (IM))
-    allocate (Interstitial%tsfc_ocean      (IM))
     allocate (Interstitial%tsfg            (IM))
     allocate (Interstitial%tsurf           (IM))
-    allocate (Interstitial%tsurf_ice       (IM))
-    allocate (Interstitial%tsurf_land      (IM))
-    allocate (Interstitial%tsurf_ocean     (IM))
     allocate (Interstitial%ud_mf           (IM,Model%levs))
     allocate (Interstitial%ulwsfc_cice     (IM))
     allocate (Interstitial%dusfc_cice      (IM))
     allocate (Interstitial%dvsfc_cice      (IM))
     allocate (Interstitial%dtsfc_cice      (IM))
     allocate (Interstitial%dqsfc_cice      (IM))
-    allocate (Interstitial%uustar_ice      (IM))
-    allocate (Interstitial%uustar_land     (IM))
-    allocate (Interstitial%uustar_ocean    (IM))
     allocate (Interstitial%vdftra          (IM,Model%levs,Interstitial%nvdiff))  !GJF first dimension was set as 'IX' in GFS_physics_driver
     allocate (Interstitial%vegf1d          (IM))
     allocate (Interstitial%vegtype         (IM))
@@ -5929,9 +5958,6 @@ module GFS_typedefs
     allocate (Interstitial%xlai1d          (IM))
     allocate (Interstitial%xmu             (IM))
     allocate (Interstitial%z01d            (IM))
-    allocate (Interstitial%zorl_ice        (IM))
-    allocate (Interstitial%zorl_land       (IM))
-    allocate (Interstitial%zorl_ocean      (IM))
     allocate (Interstitial%zt1d            (IM))
 ! CIRES UGWP v0
     allocate (Interstitial%gw_dudt         (IM,Model%levs))
@@ -6319,7 +6345,6 @@ module GFS_typedefs
     Interstitial%ep1d_ice        = huge
     Interstitial%ep1d_land       = huge
     Interstitial%ep1d_ocean      = huge
-    Interstitial%evap            = clear_val
     Interstitial%evap_ice        = huge
     Interstitial%evap_land       = huge
     Interstitial%evap_ocean      = huge
@@ -6358,7 +6383,6 @@ module GFS_typedefs
     Interstitial%gflx_ocean      = zero
     Interstitial%gwdcu           = clear_val
     Interstitial%gwdcv           = clear_val
-    Interstitial%hflx            = clear_val
     Interstitial%hflx_ice        = huge
     Interstitial%hflx_land       = huge
     Interstitial%hflx_ocean      = huge
@@ -6379,9 +6403,6 @@ module GFS_typedefs
     Interstitial%prcpmp          = clear_val
     Interstitial%prnum           = clear_val
     Interstitial%qss             = clear_val
-    Interstitial%qss_ice         = huge
-    Interstitial%qss_land        = huge
-    Interstitial%qss_ocean       = huge
     Interstitial%raincd          = clear_val
     Interstitial%raincs          = clear_val
     Interstitial%rainmcadj       = clear_val
@@ -6407,9 +6428,6 @@ module GFS_typedefs
     Interstitial%sigmatot        = clear_val
     Interstitial%slopetype       = 0
     Interstitial%snowc           = clear_val
-    Interstitial%snowd_ice       = huge
-    Interstitial%snowd_land      = huge
-    Interstitial%snowd_ocean     = huge
     Interstitial%snohf           = clear_val
     Interstitial%snowmt          = clear_val
     Interstitial%soiltype        = 0
@@ -6424,22 +6442,13 @@ module GFS_typedefs
     Interstitial%tprcp_ocean     = huge
     Interstitial%trans           = clear_val
     Interstitial%tseal           = clear_val
-    Interstitial%tsfc_ice        = huge
-    Interstitial%tsfc_land       = huge
-    Interstitial%tsfc_ocean      = huge
     Interstitial%tsurf           = clear_val
-    Interstitial%tsurf_ice       = huge
-    Interstitial%tsurf_land      = huge
-    Interstitial%tsurf_ocean     = huge
     Interstitial%ud_mf           = clear_val
     Interstitial%ulwsfc_cice     = clear_val
     Interstitial%dusfc_cice      = clear_val
     Interstitial%dvsfc_cice      = clear_val
     Interstitial%dtsfc_cice      = clear_val
     Interstitial%dqsfc_cice      = clear_val
-    Interstitial%uustar_ice      = huge
-    Interstitial%uustar_land     = huge
-    Interstitial%uustar_ocean    = huge
     Interstitial%vdftra          = clear_val
     Interstitial%vegf1d          = clear_val
     Interstitial%vegtype         = 0
@@ -6455,9 +6464,6 @@ module GFS_typedefs
     Interstitial%xlai1d          = clear_val
     Interstitial%xmu             = clear_val
     Interstitial%z01d            = clear_val
-    Interstitial%zorl_ice        = huge
-    Interstitial%zorl_land       = huge
-    Interstitial%zorl_ocean      = huge
     Interstitial%zt1d            = clear_val
 ! CIRES UGWP v0
     Interstitial%gw_dudt         = clear_val
@@ -6630,7 +6636,6 @@ module GFS_typedefs
     write (0,*) 'sum(Interstitial%ep1d_ice        ) = ', sum(Interstitial%ep1d_ice        )
     write (0,*) 'sum(Interstitial%ep1d_land       ) = ', sum(Interstitial%ep1d_land       )
     write (0,*) 'sum(Interstitial%ep1d_ocean      ) = ', sum(Interstitial%ep1d_ocean      )
-    write (0,*) 'sum(Interstitial%evap            ) = ', sum(Interstitial%evap            )
     write (0,*) 'sum(Interstitial%evap_ice        ) = ', sum(Interstitial%evap_ice        )
     write (0,*) 'sum(Interstitial%evap_land       ) = ', sum(Interstitial%evap_land       )
     write (0,*) 'sum(Interstitial%evap_ocean      ) = ', sum(Interstitial%evap_ocean      )
@@ -6673,7 +6678,6 @@ module GFS_typedefs
     write (0,*) 'sum(Interstitial%gflx_ocean      ) = ', sum(Interstitial%gflx_ocean      )
     write (0,*) 'sum(Interstitial%gwdcu           ) = ', sum(Interstitial%gwdcu           )
     write (0,*) 'sum(Interstitial%gwdcv           ) = ', sum(Interstitial%gwdcv           )
-    write (0,*) 'sum(Interstitial%hflx            ) = ', sum(Interstitial%hflx            )
     write (0,*) 'sum(Interstitial%hflx_ice        ) = ', sum(Interstitial%hflx_ice        )
     write (0,*) 'sum(Interstitial%hflx_land       ) = ', sum(Interstitial%hflx_land       )
     write (0,*) 'sum(Interstitial%hflx_ocean      ) = ', sum(Interstitial%hflx_ocean      )
@@ -6705,9 +6709,6 @@ module GFS_typedefs
     write (0,*) 'sum(Interstitial%prnum           ) = ', sum(Interstitial%prnum           )
     write (0,*) 'sum(Interstitial%qlyr            ) = ', sum(Interstitial%qlyr            )
     write (0,*) 'sum(Interstitial%qss             ) = ', sum(Interstitial%qss             )
-    write (0,*) 'sum(Interstitial%qss_ice         ) = ', sum(Interstitial%qss_ice         )
-    write (0,*) 'sum(Interstitial%qss_land        ) = ', sum(Interstitial%qss_land        )
-    write (0,*) 'sum(Interstitial%qss_ocean       ) = ', sum(Interstitial%qss_ocean       )
     write (0,*) 'Interstitial%raddt                 = ', Interstitial%raddt
     write (0,*) 'sum(Interstitial%raincd          ) = ', sum(Interstitial%raincd          )
     write (0,*) 'sum(Interstitial%raincs          ) = ', sum(Interstitial%raincs          )
@@ -6742,9 +6743,6 @@ module GFS_typedefs
     write (0,*) 'sum(Interstitial%sigmatot        ) = ', sum(Interstitial%sigmatot        )
     write (0,*) 'sum(Interstitial%slopetype       ) = ', sum(Interstitial%slopetype       )
     write (0,*) 'sum(Interstitial%snowc           ) = ', sum(Interstitial%snowc           )
-    write (0,*) 'sum(Interstitial%snowd_ice       ) = ', sum(Interstitial%snowd_ice       )
-    write (0,*) 'sum(Interstitial%snowd_land      ) = ', sum(Interstitial%snowd_land      )
-    write (0,*) 'sum(Interstitial%snowd_ocean     ) = ', sum(Interstitial%snowd_ocean     )
     write (0,*) 'sum(Interstitial%snohf           ) = ', sum(Interstitial%snohf           )
     write (0,*) 'sum(Interstitial%snowmt          ) = ', sum(Interstitial%snowmt          )
     write (0,*) 'sum(Interstitial%soiltype        ) = ', sum(Interstitial%soiltype        )
@@ -6762,23 +6760,14 @@ module GFS_typedefs
     write (0,*) 'sum(Interstitial%trans           ) = ', sum(Interstitial%trans           )
     write (0,*) 'sum(Interstitial%tseal           ) = ', sum(Interstitial%tseal           )
     write (0,*) 'sum(Interstitial%tsfa            ) = ', sum(Interstitial%tsfa            )
-    write (0,*) 'sum(Interstitial%tsfc_ice        ) = ', sum(Interstitial%tsfc_ice        )
-    write (0,*) 'sum(Interstitial%tsfc_land       ) = ', sum(Interstitial%tsfc_land       )
-    write (0,*) 'sum(Interstitial%tsfc_ocean      ) = ', sum(Interstitial%tsfc_ocean      )
     write (0,*) 'sum(Interstitial%tsfg            ) = ', sum(Interstitial%tsfg            )
     write (0,*) 'sum(Interstitial%tsurf           ) = ', sum(Interstitial%tsurf           )
-    write (0,*) 'sum(Interstitial%tsurf_ice       ) = ', sum(Interstitial%tsurf_ice       )
-    write (0,*) 'sum(Interstitial%tsurf_land      ) = ', sum(Interstitial%tsurf_land      )
-    write (0,*) 'sum(Interstitial%tsurf_ocean     ) = ', sum(Interstitial%tsurf_ocean     )
     write (0,*) 'sum(Interstitial%ud_mf           ) = ', sum(Interstitial%ud_mf           )
     write (0,*) 'sum(Interstitial%ulwsfc_cice     ) = ', sum(Interstitial%ulwsfc_cice     )
     write (0,*) 'sum(Interstitial%dusfc_cice      ) = ', sum(Interstitial%dusfc_cice      )
     write (0,*) 'sum(Interstitial%dvsfc_cice      ) = ', sum(Interstitial%dvsfc_cice      )
     write (0,*) 'sum(Interstitial%dtsfc_cice      ) = ', sum(Interstitial%dtsfc_cice      )
     write (0,*) 'sum(Interstitial%dqsfc_cice      ) = ', sum(Interstitial%dqsfc_cice      )
-    write (0,*) 'sum(Interstitial%uustar_ice      ) = ', sum(Interstitial%uustar_ice      )
-    write (0,*) 'sum(Interstitial%uustar_land     ) = ', sum(Interstitial%uustar_land     )
-    write (0,*) 'sum(Interstitial%uustar_ocean    ) = ', sum(Interstitial%uustar_ocean    )
     write (0,*) 'sum(Interstitial%vdftra          ) = ', sum(Interstitial%vdftra          )
     write (0,*) 'sum(Interstitial%vegf1d          ) = ', sum(Interstitial%vegf1d          )
     write (0,*) 'sum(Interstitial%vegtype         ) = ', sum(Interstitial%vegtype         )
@@ -6794,9 +6783,6 @@ module GFS_typedefs
     write (0,*) 'sum(Interstitial%xlai1d          ) = ', sum(Interstitial%xlai1d          )
     write (0,*) 'sum(Interstitial%xmu             ) = ', sum(Interstitial%xmu             )
     write (0,*) 'sum(Interstitial%z01d            ) = ', sum(Interstitial%z01d            )
-    write (0,*) 'sum(Interstitial%zorl_ice        ) = ', sum(Interstitial%zorl_ice        )
-    write (0,*) 'sum(Interstitial%zorl_land       ) = ', sum(Interstitial%zorl_land       )
-    write (0,*) 'sum(Interstitial%zorl_ocean      ) = ', sum(Interstitial%zorl_ocean      )
     write (0,*) 'sum(Interstitial%zt1d            ) = ', sum(Interstitial%zt1d            )
 ! CIRES UGWP v0
     write (0,*) 'sum(Interstitial%gw_dudt         ) = ', sum(Interstitial%gw_dudt         )

--- a/gfsphysics/GFS_layer/GFS_typedefs.meta
+++ b/gfsphysics/GFS_layer/GFS_typedefs.meta
@@ -1269,6 +1269,146 @@
   dimensions = (horizontal_dimension)
   type = real
   kind = kind_phys
+[evap]
+  standard_name = kinematic_surface_upward_latent_heat_flux
+  long_name = kinematic surface upward latent heat flux
+  units = kg kg-1 m s-1
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+[hflx]
+  standard_name = kinematic_surface_upward_sensible_heat_flux
+  long_name = kinematic surface upward sensible heat flux
+  units = K m s-1
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+[tsfc_ocean]
+  standard_name = surface_skin_temperature_over_ocean_interstitial
+  long_name = surface skin temperature over ocean (temporary use as interstitial)
+  units = K
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+[tsfc_land]
+  standard_name = surface_skin_temperature_over_land_interstitial
+  long_name = surface skin temperature over land  (temporary use as interstitial)
+  units = K
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+[tsfc_ice]
+  standard_name = surface_skin_temperature_over_ice_interstitial
+  long_name = surface skin temperature over ice   (temporary use as interstitial)
+  units = K
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+[tsurf_ocean]
+  standard_name = surface_skin_temperature_after_iteration_over_ocean
+  long_name = surface skin temperature after iteration over ocean
+  units = K
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+[tsurf_land]
+  standard_name = surface_skin_temperature_after_iteration_over_land
+  long_name = surface skin temperature after iteration over land
+  units = K
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+[tsurf_ice]
+  standard_name = surface_skin_temperature_after_iteration_over_ice
+  long_name = surface skin temperature after iteration over ice
+  units = K
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+[uustar_ocean]
+  standard_name = surface_friction_velocity_over_ocean
+  long_name = surface friction velocity over ocean
+  units = m s-1
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+[uustar_land]
+  standard_name = surface_friction_velocity_over_land
+  long_name = surface friction velocity over land
+  units = m s-1
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+[uustar_ice]
+  standard_name = surface_friction_velocity_over_ice
+  long_name = surface friction velocity over ice
+  units = m s-1
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+[qss_ocean]
+  standard_name = surface_specific_humidity_over_ocean
+  long_name = surface air saturation specific humidity over ocean
+  units = kg kg-1
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+[qss_land]
+  standard_name = surface_specific_humidity_over_land
+  long_name = surface air saturation specific humidity over land
+  units = kg kg-1
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+[qss_ice]
+  standard_name = surface_specific_humidity_over_ice
+  long_name = surface air saturation specific humidity over ice
+  units = kg kg-1
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+[snowd_ocean]
+  standard_name = surface_snow_thickness_water_equivalent_over_ocean
+  long_name = water equivalent snow depth over ocean
+  units = mm
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+[snowd_land]
+  standard_name = surface_snow_thickness_water_equivalent_over_land
+  long_name = water equivalent snow depth over land
+  units = mm
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+[snowd_ice]
+  standard_name = surface_snow_thickness_water_equivalent_over_ice
+  long_name = water equivalent snow depth over ice
+  units = mm
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+[zorl_ocean]
+  standard_name = surface_roughness_length_over_ocean_interstitial
+  long_name = surface roughness length over ocean (temporary use as interstitial)
+  units = cm
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+[zorl_land]
+  standard_name = surface_roughness_length_over_land_interstitial
+  long_name = surface roughness length over land  (temporary use as interstitial)
+  units = cm
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+[zorl_ice]
+  standard_name = surface_roughness_length_over_ice_interstitial
+  long_name = surface roughness length over ice   (temporary use as interstitial)
+  units = cm
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
 [raincprv]
   standard_name = lwe_thickness_of_convective_precipitation_amount_from_previous_timestep
   long_name = convective_precipitation_amount from previous timestep
@@ -4091,6 +4231,13 @@
   dimensions = (horizontal_dimension,vertical_dimension_of_h2o_forcing_data,number_of_coefficients_in_h2o_forcing_data)
   type = real
   kind = kind_phys
+[hpbl]
+  standard_name = atmosphere_boundary_layer_thickness
+  long_name = pbl height
+  units = m
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
 [in_nm]
   standard_name = in_number_concentration
   long_name = IN number concentration
@@ -5118,13 +5265,6 @@
   standard_name = surface_air_pressure_diag
   long_name = surface air pressure diagnostic
   units = Pa
-  dimensions = (horizontal_dimension)
-  type = real
-  kind = kind_phys
-[hpbl]
-  standard_name = atmosphere_boundary_layer_thickness
-  long_name = pbl height
-  units = m
   dimensions = (horizontal_dimension)
   type = real
   kind = kind_phys
@@ -6634,13 +6774,6 @@
   dimensions = (horizontal_dimension)
   type = real
   kind = kind_phys
-[evap]
-  standard_name = kinematic_surface_upward_latent_heat_flux
-  long_name = kinematic surface upward latent heat flux
-  units = kg kg-1 m s-1
-  dimensions = (horizontal_dimension)
-  type = real
-  kind = kind_phys
 [evap_ocean]
   standard_name = kinematic_surface_upward_latent_heat_flux_over_ocean
   long_name = kinematic surface upward latent heat flux over ocean
@@ -7055,13 +7188,6 @@
   long_name = natural log of h2o forcing data pressure levels
   units = log(Pa)
   dimensions = (vertical_dimension_of_h2o_forcing_data)
-  type = real
-  kind = kind_phys
-[hflx]
-  standard_name = kinematic_surface_upward_sensible_heat_flux
-  long_name = kinematic surface upward sensible heat flux
-  units = K m s-1
-  dimensions = (horizontal_dimension)
   type = real
   kind = kind_phys
 [hflx_ocean]
@@ -7515,27 +7641,6 @@
   dimensions = (horizontal_dimension)
   type = real
   kind = kind_phys
-[qss_ocean]
-  standard_name = surface_specific_humidity_over_ocean
-  long_name = surface air saturation specific humidity over ocean
-  units = kg kg-1
-  dimensions = (horizontal_dimension)
-  type = real
-  kind = kind_phys
-[qss_land]
-  standard_name = surface_specific_humidity_over_land
-  long_name = surface air saturation specific humidity over land
-  units = kg kg-1
-  dimensions = (horizontal_dimension)
-  type = real
-  kind = kind_phys
-[qss_ice]
-  standard_name = surface_specific_humidity_over_ice
-  long_name = surface air saturation specific humidity over ice
-  units = kg kg-1
-  dimensions = (horizontal_dimension)
-  type = real
-  kind = kind_phys
 [raddt]
   standard_name = time_step_for_radiation
   long_name = radiation time step
@@ -7770,27 +7875,6 @@
   dimensions = (horizontal_dimension)
   type = real
   kind = kind_phys
-[snowd_ocean]
-  standard_name = surface_snow_thickness_water_equivalent_over_ocean
-  long_name = water equivalent snow depth over ocean
-  units = mm
-  dimensions = (horizontal_dimension)
-  type = real
-  kind = kind_phys
-[snowd_land]
-  standard_name = surface_snow_thickness_water_equivalent_over_land
-  long_name = water equivalent snow depth over land
-  units = mm
-  dimensions = (horizontal_dimension)
-  type = real
-  kind = kind_phys
-[snowd_ice]
-  standard_name = surface_snow_thickness_water_equivalent_over_ice
-  long_name = water equivalent snow depth over ice
-  units = mm
-  dimensions = (horizontal_dimension)
-  type = real
-  kind = kind_phys
 [snohf]
   standard_name = snow_freezing_rain_upward_latent_heat_flux
   long_name = latent heat flux due to snow and frz rain
@@ -7941,27 +8025,6 @@
   dimensions = (horizontal_dimension)
   type = real
   kind = kind_phys
-[tsfc_ocean]
-  standard_name = surface_skin_temperature_over_ocean_interstitial
-  long_name = surface skin temperature over ocean (temporary use as interstitial)
-  units = K
-  dimensions = (horizontal_dimension)
-  type = real
-  kind = kind_phys
-[tsfc_land]
-  standard_name = surface_skin_temperature_over_land_interstitial
-  long_name = surface skin temperature over land  (temporary use as interstitial)
-  units = K
-  dimensions = (horizontal_dimension)
-  type = real
-  kind = kind_phys
-[tsfc_ice]
-  standard_name = surface_skin_temperature_over_ice_interstitial
-  long_name = surface skin temperature over ice   (temporary use as interstitial)
-  units = K
-  dimensions = (horizontal_dimension)
-  type = real
-  kind = kind_phys
 [tsfg]
   standard_name = surface_ground_temperature_for_radiation
   long_name = surface ground temperature for radiation
@@ -7972,27 +8035,6 @@
 [tsurf]
   standard_name = surface_skin_temperature_after_iteration
   long_name = surface skin temperature after iteration
-  units = K
-  dimensions = (horizontal_dimension)
-  type = real
-  kind = kind_phys
-[tsurf_ocean]
-  standard_name = surface_skin_temperature_after_iteration_over_ocean
-  long_name = surface skin temperature after iteration over ocean
-  units = K
-  dimensions = (horizontal_dimension)
-  type = real
-  kind = kind_phys
-[tsurf_land]
-  standard_name = surface_skin_temperature_after_iteration_over_land
-  long_name = surface skin temperature after iteration over land
-  units = K
-  dimensions = (horizontal_dimension)
-  type = real
-  kind = kind_phys
-[tsurf_ice]
-  standard_name = surface_skin_temperature_after_iteration_over_ice
-  long_name = surface skin temperature after iteration over ice
   units = K
   dimensions = (horizontal_dimension)
   type = real
@@ -8014,27 +8056,6 @@
   standard_name = surface_upwelling_longwave_flux_for_coupling_interstitial
   long_name = surface upwelling longwave flux for coupling_interstitial
   units = W m-2
-  dimensions = (horizontal_dimension)
-  type = real
-  kind = kind_phys
-[uustar_ocean]
-  standard_name = surface_friction_velocity_over_ocean
-  long_name = surface friction velocity over ocean
-  units = m s-1
-  dimensions = (horizontal_dimension)
-  type = real
-  kind = kind_phys
-[uustar_land]
-  standard_name = surface_friction_velocity_over_land
-  long_name = surface friction velocity over land
-  units = m s-1
-  dimensions = (horizontal_dimension)
-  type = real
-  kind = kind_phys
-[uustar_ice]
-  standard_name = surface_friction_velocity_over_ice
-  long_name = surface friction velocity over ice
-  units = m s-1
   dimensions = (horizontal_dimension)
   type = real
   kind = kind_phys
@@ -8146,27 +8167,6 @@
   standard_name = perturbation_of_momentum_roughness_length
   long_name = perturbation of momentum roughness length
   units = frac
-  dimensions = (horizontal_dimension)
-  type = real
-  kind = kind_phys
-[zorl_ocean]
-  standard_name = surface_roughness_length_over_ocean_interstitial
-  long_name = surface roughness length over ocean (temporary use as interstitial)
-  units = cm
-  dimensions = (horizontal_dimension)
-  type = real
-  kind = kind_phys
-[zorl_land]
-  standard_name = surface_roughness_length_over_land_interstitial
-  long_name = surface roughness length over land  (temporary use as interstitial)
-  units = cm
-  dimensions = (horizontal_dimension)
-  type = real
-  kind = kind_phys
-[zorl_ice]
-  standard_name = surface_roughness_length_over_ice_interstitial
-  long_name = surface roughness length over ice   (temporary use as interstitial)
-  units = cm
   dimensions = (horizontal_dimension)
   type = real
   kind = kind_phys

--- a/gfsphysics/physics/GFS_debug.F90
+++ b/gfsphysics/physics/GFS_debug.F90
@@ -172,7 +172,7 @@
                         call print_var(mpirank,omprank, blkno, 'Sfcprop%dt_cool ', Sfcprop%dt_cool)
                         call print_var(mpirank,omprank, blkno, 'Sfcprop%qrain   ', Sfcprop%qrain)
                      end if
-                     ! CCPP only
+                     ! CCPP/RUC only
                      !if (Model%lsm == Model%lsm_ruc) then
                      !   call print_var(mpirank,omprank, blkno, 'Sfcprop%sh2o',        Sfcprop%sh2o)
                      !   call print_var(mpirank,omprank, blkno, 'Sfcprop%smois',       Sfcprop%smois)
@@ -215,6 +215,7 @@
                      call print_var(mpirank,omprank, blkno, 'Tbd%acv'             , Tbd%acv)
                      call print_var(mpirank,omprank, blkno, 'Tbd%acvb'            , Tbd%acvb)
                      call print_var(mpirank,omprank, blkno, 'Tbd%acvt'            , Tbd%acvt)
+                     call print_var(mpirank,omprank, blkno, 'Tbd%hpbl'            , Tbd%hpbl)
                      if (Model%do_sppt) then
                        call print_var(mpirank,omprank, blkno, 'Tbd%dtdtr'         , Tbd%dtdtr)
                        call print_var(mpirank,omprank, blkno, 'Tbd%dtotprcp'      , Tbd%dtotprcp)
@@ -284,7 +285,6 @@
                      call print_var(mpirank,omprank, blkno, 'Diag%dpt2m       ',    Diag%dpt2m)
                      call print_var(mpirank,omprank, blkno, 'Diag%zlvl        ',    Diag%zlvl)
                      call print_var(mpirank,omprank, blkno, 'Diag%psurf       ',    Diag%psurf)
-                     call print_var(mpirank,omprank, blkno, 'Diag%hpbl        ',    Diag%hpbl)
                      call print_var(mpirank,omprank, blkno, 'Diag%pwat        ',    Diag%pwat)
                      call print_var(mpirank,omprank, blkno, 'Diag%t1          ',    Diag%t1)
                      call print_var(mpirank,omprank, blkno, 'Diag%q1          ',    Diag%q1)
@@ -300,7 +300,7 @@
                      call print_var(mpirank,omprank, blkno, 'Diag%tdomzr      ',    Diag%tdomzr)
                      call print_var(mpirank,omprank, blkno, 'Diag%tdomip      ',    Diag%tdomip)
                      call print_var(mpirank,omprank, blkno, 'Diag%tdoms       ',    Diag%tdoms)
-                     ! CCPP only
+                     ! CCPP/RUC only
                      !if (Model%lsm == Model%lsm_ruc) then
                      !  call print_var(mpirank,omprank, blkno, 'Diag%wet1        ',  Sfcprop%wetness)
                      !else
@@ -336,7 +336,7 @@
                      if(Model%lradar) then
                        call print_var(mpirank,omprank, blkno, 'Diag%refl_10cm   ',  Diag%refl_10cm)
                      end if
-                     ! CCPP only
+                     ! CCPP/MYNNPBL only
                      !if (Model%do_mynnedmf) then
                      !  call print_var(mpirank,omprank, blkno, 'Diag%edmf_a      ',  Diag%edmf_a)
                      !  call print_var(mpirank,omprank, blkno, 'Diag%edmf_w      ',  Diag%edmf_w)


### PR DESCRIPTION
This PR is to create a backup in NOAA-GSD/fv3atm for Joe's MYNNSFCLAY code before reverting the change to the composites in `GFS_typedefs.F90` (i.e. the idea to make them persistent).

No testing required. New/backup branch in NOAA-GSD/fv3atm is called "mynnsfclay_from_joe_in_latest_code_without_reversing_composites_in_typedefs_20200319"