### PR TITLE
Output of auxiliary 2d/3d arrays from CCPP (and other parts of the model)

### DIFF
--- a/gfsphysics/GFS_layer/GFS_diagnostics.F90
+++ b/gfsphysics/GFS_layer/GFS_diagnostics.F90
@@ -3910,6 +3910,40 @@ module GFS_diagnostics
 !rab    ExtDiag(idx)%unit = 'kg/kg/s'
 !rab    ExtDiag(idx)%mod_name = 'gfs_phys'
 
+  ! Auxiliary 2d arrays to output (for debugging)
+  do num=1,Model%naux2d
+    write (xtra,'(I2.2)') num
+    idx = idx + 1
+    ExtDiag(idx)%axes = 2
+    ExtDiag(idx)%name = 'aux2d_'//trim(xtra)
+    ExtDiag(idx)%desc = 'auxiliary 2d array '//trim(xtra)
+    ExtDiag(idx)%unit = 'unknown'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    ExtDiag(idx)%intpl_method = 'bilinear'
+    ExtDiag(idx)%time_avg = Model%aux2d_time_avg(num)
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var2 => IntDiag(nb)%aux2d(:,num)
+    enddo
+  enddo
+
+  ! Auxiliary 3d arrays to output (for debugging)
+  do num=1,Model%naux3d
+    write (xtra,'(I2.2)') num
+    idx = idx + 1
+    ExtDiag(idx)%axes = 3
+    ExtDiag(idx)%name = 'aux3d_'//trim(xtra)
+    ExtDiag(idx)%desc = 'auxiliary 3d array '//trim(xtra)
+    ExtDiag(idx)%unit = 'unknown'
+    ExtDiag(idx)%mod_name = 'gfs_phys'
+    ExtDiag(idx)%intpl_method = 'bilinear'
+    ExtDiag(idx)%time_avg = Model%aux3d_time_avg(num)
+    allocate (ExtDiag(idx)%data(nblks))
+    do nb = 1,nblks
+      ExtDiag(idx)%data(nb)%var3 => IntDiag(nb)%aux3d(:,:,num)
+    enddo
+  enddo
+
   end subroutine GFS_externaldiag_populate
 
 #ifdef CCPP

--- a/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -560,12 +560,8 @@ module GFS_typedefs
     logical              :: lssav           !< logical flag for storing diagnostics
     integer              :: naux2d          !< number of auxiliary 2d arrays to output (for debugging)
     integer              :: naux3d          !< number of auxiliary 3d arrays to output (for debugging)
-    logical, pointer     :: aux2d_time_avg(:)   !< flags for time averaging of auxiliary 2d arrays
-    logical, pointer     :: aux3d_time_avg(:)   !< flags for time averaging of auxiliary 3d arrays
-    logical, pointer     :: aux2d_rad_reset(:)  !< flags for resettig auxiliary 2d arrays when radiation diags are reset
-    logical, pointer     :: aux3d_rad_reset(:)  !< flags for resettig auxiliary 3d arrays when radiation diags are reset
-    logical, pointer     :: aux2d_phys_reset(:) !< flags for resettig auxiliary 2d arrays when physics diags are reset
-    logical, pointer     :: aux3d_phys_reset(:) !< flags for resettig auxiliary 3d arrays when physics diags are reset
+    logical, pointer     :: aux2d_time_avg(:) !< flags for time averaging of auxiliary 2d arrays
+    logical, pointer     :: aux3d_time_avg(:) !< flags for time averaging of auxiliary 3d arrays
 
     real(kind=kind_phys) :: fhcyc           !< frequency for surface data cycling (hours)
     integer              :: thermodyn_id    !< valid for GFS only for get_prs/phi
@@ -2758,12 +2754,8 @@ module GFS_typedefs
     logical              :: lssav          = .false.         !< logical flag for storing diagnostics
     integer              :: naux2d         = 0               !< number of auxiliary 2d arrays to output (for debugging)
     integer              :: naux3d         = 0               !< number of auxiliary 3d arrays to output (for debugging)
-    logical              :: aux2d_time_avg(1:naux2dmax) = .false.   !< flags for time averaging of auxiliary 2d arrays
-    logical              :: aux3d_time_avg(1:naux3dmax) = .false.   !< flags for time averaging of auxiliary 3d arrays
-    logical              :: aux2d_rad_reset(1:naux2dmax) = .false.  !< flags for resettig auxiliary 2d arrays when radiation diags are reset
-    logical              :: aux3d_rad_reset(1:naux3dmax) = .false.  !< flags for resettig auxiliary 3d arrays when radiation diags are reset
-    logical              :: aux2d_phys_reset(1:naux2dmax) = .false. !< flags for resettig auxiliary 2d arrays when physics diags are reset
-    logical              :: aux3d_phys_reset(1:naux3dmax) = .false. !< flags for resettig auxiliary 3d arrays when physics diags are reset
+    logical              :: aux2d_time_avg(1:naux2dmax) = .false. !< flags for time averaging of auxiliary 2d arrays
+    logical              :: aux3d_time_avg(1:naux3dmax) = .false. !< flags for time averaging of auxiliary 3d arrays
 
     real(kind=kind_phys) :: fhcyc          = 0.              !< frequency for surface data cycling (hours)
     integer              :: thermodyn_id   =  1              !< valid for GFS only for get_prs/phi
@@ -3145,8 +3137,7 @@ module GFS_typedefs
     NAMELIST /gfs_physics_nml/                                                              &
                           !--- general parameters
                                fhzero, ldiag3d, qdiag3d, lssav, naux2d, naux3d,             &
-                               aux2d_time_avg, aux3d_time_avg, aux2d_rad_reset,             &
-                               aux3d_rad_reset, aux2d_phys_reset, aux3d_phys_reset, fhcyc,  &
+                               aux2d_time_avg, aux3d_time_avg, fhcyc,                       &
                                thermodyn_id, sfcpress_id,                                   &
                           !--- coupling parameters
                                cplflx, cplwav, cplchm, lsidea,                              &
@@ -3368,20 +3359,12 @@ module GFS_typedefs
     Model%naux2d           = naux2d
     Model%naux3d           = naux3d
     if (Model%naux2d>0) then
-        allocate(Model%aux2d_time_avg   (1:naux2d))
-        allocate(Model%aux2d_rad_reset  (1:naux2d))
-        allocate(Model%aux2d_phys_reset (1:naux2d))
-        Model%aux2d_time_avg(1:naux2d)   = aux2d_time_avg(1:naux2d)
-        Model%aux2d_rad_reset(1:naux2d)  = aux2d_rad_reset(1:naux2d)
-        Model%aux2d_phys_reset(1:naux2d) = aux2d_phys_reset(1:naux2d)
+        allocate(Model%aux2d_time_avg(1:naux2d))
+        Model%aux2d_time_avg(1:naux2d) = aux2d_time_avg(1:naux2d)
     end if
     if (Model%naux3d>0) then
-        allocate(Model%aux3d_time_avg   (1:naux3d))
-        allocate(Model%aux3d_rad_reset  (1:naux3d))
-        allocate(Model%aux3d_phys_reset (1:naux3d))
-        Model%aux3d_time_avg(1:naux3d)   = aux3d_time_avg(1:naux3d)
-        Model%aux3d_rad_reset(1:naux3d)  = aux3d_rad_reset(1:naux3d)
-        Model%aux3d_phys_reset(1:naux3d) = aux3d_phys_reset(1:naux3d)
+        allocate(Model%aux3d_time_avg(1:naux3d))
+        Model%aux3d_time_avg(1:naux3d) = aux3d_time_avg(1:naux3d)
     end if
     !
     Model%fhcyc            = fhcyc
@@ -4524,13 +4507,9 @@ module GFS_typedefs
       print *, ' naux3d            : ', Model%naux3d
       if (Model%naux2d>0) then
         print *, ' aux2d_time_avg    : ', Model%aux2d_time_avg
-        print *, ' aux2d_rad_reset   : ', Model%aux2d_rad_reset
-        print *, ' aux2d_phys_reset  : ', Model%aux2d_phys_reset
       endif
       if (Model%naux3d>0) then
         print *, ' aux3d_time_avg    : ', Model%aux3d_time_avg
-        print *, ' aux3d_rad_reset   : ', Model%aux3d_rad_reset
-        print *, ' aux3d_phys_reset  : ', Model%aux3d_phys_reset
       endif
       print *, ' fhcyc             : ', Model%fhcyc
       print *, ' thermodyn_id      : ', Model%thermodyn_id
@@ -5532,13 +5511,6 @@ module GFS_typedefs
       Diag%cldcov     = zero
     endif
 
-    do i=1,Model%naux2d
-      if (Model%aux2d_rad_reset(i)) Diag%aux2d(:,i) = zero
-    enddo
-    do i=1,Model%naux3d
-      if (Model%aux3d_rad_reset(i)) Diag%aux3d(:,:,i) = zero
-    enddo
-
   end subroutine diag_rad_zero
 
 !------------------------
@@ -5750,13 +5722,6 @@ module GFS_typedefs
       Diag%totsnw  = zero
       Diag%totgrp  = zero
     endif
-
-    do i=1,Model%naux2d
-      if (Model%aux2d_phys_reset(i)) Diag%aux2d(:,i) = zero
-    enddo
-    do i=1,Model%naux3d
-      if (Model%aux3d_phys_reset(i)) Diag%aux3d(:,:,i) = zero
-    enddo
 
   end subroutine diag_phys_zero
 

--- a/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -5533,10 +5533,10 @@ module GFS_typedefs
     endif
 
     do i=1,Model%naux2d
-      if (Model%aux2d_rad_reset(i)) Diag%aux2d(:,i) = clear_val
+      if (Model%aux2d_rad_reset(i)) Diag%aux2d(:,i) = zero
     enddo
     do i=1,Model%naux3d
-      if (Model%aux3d_rad_reset(i)) Diag%aux3d(:,:,i) = clear_val
+      if (Model%aux3d_rad_reset(i)) Diag%aux3d(:,:,i) = zero
     enddo
 
   end subroutine diag_rad_zero
@@ -5752,10 +5752,10 @@ module GFS_typedefs
     endif
 
     do i=1,Model%naux2d
-      if (Model%aux2d_phys_reset(i)) Diag%aux2d(:,i) = clear_val
+      if (Model%aux2d_phys_reset(i)) Diag%aux2d(:,i) = zero
     enddo
     do i=1,Model%naux3d
-      if (Model%aux3d_phys_reset(i)) Diag%aux3d(:,:,i) = clear_val
+      if (Model%aux3d_phys_reset(i)) Diag%aux3d(:,:,i) = zero
     enddo
 
   end subroutine diag_phys_zero

--- a/gfsphysics/GFS_layer/GFS_typedefs.meta
+++ b/gfsphysics/GFS_layer/GFS_typedefs.meta
@@ -1998,6 +1998,18 @@
   units = flag
   dimensions = ()
   type = logical
+[naux2d]
+  standard_name = number_of_2d_auxiliary_arrays
+  long_name = number of 2d auxiliary arrays to output (for debugging)
+  units = count
+  dimensions = ()
+  type = integer
+[naux3d]
+  standard_name = number_of_3d_auxiliary_arrays
+  long_name = number of 3d auxiliary arrays to output (for debugging)
+  units = count
+  dimensions = ()
+  type = integer
 [levs]
   standard_name = vertical_dimension
   long_name = number of vertical levels
@@ -5983,6 +5995,20 @@
   long_name = time integral of change in y wind due to NGW
   units = m s-2
   dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+[aux2d]
+  standard_name = auxiliary_2d_arrays
+  long_name = auxiliary 2d arrays to output (for debugging)
+  units = none
+  dimensions = (horizontal_dimension,number_of_3d_auxiliary_arrays)
+  type = real
+  kind = kind_phys
+[aux3d]
+  standard_name = auxiliary_3d_arrays
+  long_name = auxiliary 3d arrays to output (for debugging)
+  units = none
+  dimensions = (horizontal_dimension,vertical_dimension,number_of_3d_auxiliary_arrays)
   type = real
   kind = kind_phys
 


### PR DESCRIPTION
This PR adds the capability to output auxiliary 2d/3d data from CCPP (and other parts of the model).

For the description of the problem and the proposed solution, see 
https://docs.google.com/document/d/1VVHMR89vw6m3ADvAkipvDRiga6GffsVKpYYEZBVnkFU/edit?usp=sharing

In brief, this PR adds the required host model variables and metadata to GFS_typedefs.* and registers the output fields in GFS_diagnostics.F90. Developers who want to use these arrays will need to add the metadata and variables to their physics scheme and populate the arrays inside their scheme (as in the example below).

Associated PRs:
https://github.com/NOAA-GSD/fv3atm/pull/21
https://github.com/NOAA-GSD/ufs-weather-model/pull/17

For regression testing, see https://github.com/NOAA-GSD/ufs-weather-model/pull/17.