### PR TITLE
Cleanup of Thompson MP cloud effective radii calculation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,7 @@
 	branch = gsd/develop
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/NOAA-GSD/ccpp-physics
-	branch = gsd/develop
+	#url = https://github.com/NOAA-GSD/ccpp-physics
+	#branch = gsd/develop
+	url = https://github.com/climbfuji/ccpp-physics
+	branch = thompson_mp_cloud_effective_radii_cleanup

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,5 @@
 	branch = gsd/develop
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	#url = https://github.com/NOAA-GSD/ccpp-physics
-	#branch = gsd/develop
-	url = https://github.com/climbfuji/ccpp-physics
-	branch = thompson_mp_cloud_effective_radii_cleanup
+	url = https://github.com/NOAA-GSD/ccpp-physics
+	branch = gsd/develop

--- a/ccpp/config/ccpp_prebuild_config.py
+++ b/ccpp/config/ccpp_prebuild_config.py
@@ -402,9 +402,11 @@ OPTIONAL_ARGUMENTS = {
             'ice_friendly_aerosol_number_concentration',
             'tendency_of_water_friendly_aerosols_at_surface',
             'tendency_of_ice_friendly_aerosols_at_surface',
-            'effective_radius_of_stratiform_cloud_liquid_water_particle_in_um',
-            'effective_radius_of_stratiform_cloud_ice_particle_in_um',
-            'effective_radius_of_stratiform_cloud_snow_particle_in_um',
+            # DH* 2020-06-01: turn off calculation of effective radii, now done in GFS_rrtmg_pre
+            #'effective_radius_of_stratiform_cloud_liquid_water_particle_in_um',
+            #'effective_radius_of_stratiform_cloud_ice_particle_in_um',
+            #'effective_radius_of_stratiform_cloud_snow_particle_in_um',
+            # *DH 2020-06-01
             ],
         'mp_thompson_run' : [
             'cloud_droplet_number_concentration_updated_by_physics',
@@ -412,9 +414,11 @@ OPTIONAL_ARGUMENTS = {
             'ice_friendly_aerosol_number_concentration_updated_by_physics',
             'tendency_of_water_friendly_aerosols_at_surface',
             'tendency_of_ice_friendly_aerosols_at_surface',
-            'effective_radius_of_stratiform_cloud_liquid_water_particle_in_um',
-            'effective_radius_of_stratiform_cloud_ice_particle_in_um',
-            'effective_radius_of_stratiform_cloud_snow_particle_in_um',
+            # DH* 2020-06-01: turn off calculation of effective radii, now done in GFS_rrtmg_pre
+            #'effective_radius_of_stratiform_cloud_liquid_water_particle_in_um',
+            #'effective_radius_of_stratiform_cloud_ice_particle_in_um',
+            #'effective_radius_of_stratiform_cloud_snow_particle_in_um',
+            # *DH 2020-06-01
             ],
         },
     'mp_fer_hires' : {


### PR DESCRIPTION
Changes in this PR:
- ccpp/config/ccpp_prebuild_config.py: turn off calculation of cloud effective radii in mp_thompson_init and mp_thompson_run, this is done in GFS_rrtmg_pre_run

Associated PRs:
https://github.com/NOAA-GSD/ccpp-physics/pull/30
https://github.com/NOAA-GSD/fv3atm/pull/31
https://github.com/NOAA-GSD/ufs-weather-model/pull/24

For regression testing information, see https://github.com/NOAA-GSD/ufs-weather-model/pull/24.