### PR TITLE
Two FV3 dycore bug fixes and SGS cloud update gsd/develop 2020/06/29

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,15 @@
 [submodule "atmos_cubed_sphere"]
 	path = atmos_cubed_sphere
-	url = https://github.com/NOAA-GSD/GFDL_atmos_cubed_sphere
-	branch = gsd/develop
+	#url = https://github.com/NOAA-GSD/GFDL_atmos_cubed_sphere
+	#branch = gsd/develop
+	url = https://github.com/climbfuji/GFDL_atmos_cubed_sphere
+	branch = dycore_bugfixes_for_gsd_develop_20200629
 [submodule "ccpp/framework"]
 	path = ccpp/framework
 	url = https://github.com/NOAA-GSD/ccpp-framework
 	branch = gsd/develop
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/NOAA-GSD/ccpp-physics
+	#url = https://github.com/NOAA-GSD/ccpp-physics
+	url = https://github.com/joeolson42/ccpp-physics
 	branch = gsd/develop

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,15 +1,12 @@
 [submodule "atmos_cubed_sphere"]
 	path = atmos_cubed_sphere
-	#url = https://github.com/NOAA-GSD/GFDL_atmos_cubed_sphere
-	#branch = gsd/develop
-	url = https://github.com/climbfuji/GFDL_atmos_cubed_sphere
-	branch = dycore_bugfixes_for_gsd_develop_20200629
+	url = https://github.com/NOAA-GSD/GFDL_atmos_cubed_sphere
+	branch = gsd/develop
 [submodule "ccpp/framework"]
 	path = ccpp/framework
 	url = https://github.com/NOAA-GSD/ccpp-framework
 	branch = gsd/develop
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	#url = https://github.com/NOAA-GSD/ccpp-physics
-	url = https://github.com/joeolson42/ccpp-physics
+	url = https://github.com/NOAA-GSD/ccpp-physics
 	branch = gsd/develop


### PR DESCRIPTION
This PR only updates the submodule pointers for GFDL_atmos_cubed_sphere and ccpp-physics for the changes described in the PRs below.

Also included is a formal update from NOAA-EMC (which only contains parts of the changes described above).

Associated PRs:
https://github.com/NOAA-GSD/ccpp-physics/pull/42
https://github.com/NOAA-GSD/GFDL_atmos_cubed_sphere/pull/5
https://github.com/NOAA-GSD/fv3atm/pull/39
https://github.com/NOAA-GSD/ufs-weather-model/pull/32

For regression testing information, see https://github.com/NOAA-GSD/ufs-weather-model/pull/32.