### PR TITLE
Add tracer sanitizer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,5 @@
 	branch = gsd/develop
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	#url = https://github.com/NOAA-GSD/ccpp-physics
-	#branch = gsd/develop
-	url = https://github.com/climbfuji/ccpp-physics
-	branch = tracer_sanitizer
+	url = https://github.com/NOAA-GSD/ccpp-physics
+	branch = gsd/develop

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,7 @@
 	branch = gsd/develop
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/NOAA-GSD/ccpp-physics
-	branch = gsd/develop
+	#url = https://github.com/NOAA-GSD/ccpp-physics
+	#branch = gsd/develop
+	url = https://github.com/climbfuji/ccpp-physics
+	branch = tracer_sanitizer

--- a/ccpp/config/ccpp_prebuild_config.py
+++ b/ccpp/config/ccpp_prebuild_config.py
@@ -187,6 +187,7 @@ SCHEME_FILES_DEPENDENCIES = [
     'FV3/ccpp/physics/physics/rte-rrtmgp/rte/mo_rte_kind.F90',
     'FV3/ccpp/physics/physics/rte-rrtmgp/rte/mo_rte_lw.F90',
     'FV3/ccpp/physics/physics/rte-rrtmgp/rte/mo_rte_sw.F90',
+    'FV3/ccpp/physics/physics/rte-rrtmgp/rte/mo_rte_config.F90',
     'FV3/ccpp/physics/physics/rte-rrtmgp/rte/mo_source_functions.F90',
     'FV3/ccpp/physics/physics/rte-rrtmgp/rte/kernels/mo_fluxes_broadband_kernels.F90',
     'FV3/ccpp/physics/physics/rte-rrtmgp/rte/kernels/mo_optical_props_kernels.F90',
@@ -198,7 +199,9 @@ SCHEME_FILES_DEPENDENCIES = [
     'FV3/ccpp/physics/physics/rte-rrtmgp/extensions/mo_heating_rates.F90',
     'FV3/ccpp/physics/physics/rte-rrtmgp/extensions/mo_rrtmgp_clr_all_sky.F90',
     'FV3/ccpp/physics/physics/rte-rrtmgp/extensions/cloud_optics/mo_cloud_optics.F90',
-    'FV3/ccpp/physics/physics/rte-rrtmgp/extensions/cloud_optics/mo_cloud_sampling.F90',
+    'FV3/ccpp/physics/physics/rrtmg_lw_cloud_optics.F90'        ,
+    'FV3/ccpp/physics/physics/rrtmg_sw_cloud_optics.F90'        ,
+    'FV3/ccpp/physics/physics/rrtmgp_aux.F90'                   ,
     # derived data type definitions
     'FV3/gfsphysics/GFS_layer/GFS_typedefs.F90',
     'FV3/gfsphysics/CCPP_layer/CCPP_typedefs.F90',
@@ -297,25 +300,26 @@ SCHEME_FILES = [
     # HAFSFER_HIRES
     'FV3/ccpp/physics/physics/mp_fer_hires.F90',
     # RRTMGP
-    'FV3/ccpp/physics/physics/rrtmg_lw_cloud_optics.F90',
-    'FV3/ccpp/physics/physics/rrtmg_sw_cloud_optics.F90',
-    'FV3/ccpp/physics/physics/rrtmgp_aux.F90',
-    'FV3/ccpp/physics/physics/rrtmgp_lw_gas_optics.F90',
-    'FV3/ccpp/physics/physics/rrtmgp_lw_cloud_optics.F90',
-    'FV3/ccpp/physics/physics/rrtmgp_sw_gas_optics.F90',
-    'FV3/ccpp/physics/physics/rrtmgp_sw_cloud_optics.F90',
-    'FV3/ccpp/physics/physics/rrtmgp_sw_aerosol_optics.F90',
-    'FV3/ccpp/physics/physics/rrtmgp_lw_rte.F90',
-    'FV3/ccpp/physics/physics/rrtmgp_lw_cloud_sampling.F90',
-    'FV3/ccpp/physics/physics/rrtmgp_sw_rte.F90',
-    'FV3/ccpp/physics/physics/rrtmgp_sw_cloud_sampling.F90',
-    'FV3/ccpp/physics/physics/rrtmgp_lw_aerosol_optics.F90',
-    'FV3/ccpp/physics/physics/GFS_rrtmgp_setup.F90',
-    'FV3/ccpp/physics/physics/GFS_rrtmgp_pre.F90',
-    'FV3/ccpp/physics/physics/rrtmgp_lw_pre.F90',
-    'FV3/ccpp/physics/physics/GFS_rrtmgp_sw_pre.F90',
-    'FV3/ccpp/physics/physics/GFS_rrtmgp_lw_post.F90',
-    'FV3/ccpp/physics/physics/GFS_rrtmgp_sw_post.F90',
+    'FV3/ccpp/physics/physics/rrtmgp_lw_gas_optics.F90'         ,
+    'FV3/ccpp/physics/physics/rrtmgp_lw_cloud_optics.F90'       ,
+    'FV3/ccpp/physics/physics/rrtmgp_sw_gas_optics.F90'         ,
+    'FV3/ccpp/physics/physics/rrtmgp_sw_cloud_optics.F90'       ,
+    'FV3/ccpp/physics/physics/rrtmgp_sw_aerosol_optics.F90'     ,
+    'FV3/ccpp/physics/physics/rrtmgp_lw_rte.F90'                ,
+    'FV3/ccpp/physics/physics/rrtmgp_sw_rte.F90'                ,
+    'FV3/ccpp/physics/physics/rrtmgp_lw_aerosol_optics.F90'     ,
+    'FV3/ccpp/physics/physics/GFS_rrtmgp_setup.F90'             ,
+    'FV3/ccpp/physics/physics/GFS_rrtmgp_pre.F90'               ,
+    'FV3/ccpp/physics/physics/rrtmgp_lw_pre.F90'                ,
+    'FV3/ccpp/physics/physics/GFS_rrtmgp_sw_pre.F90'            ,
+    'FV3/ccpp/physics/physics/GFS_rrtmgp_lw_post.F90'           ,
+    'FV3/ccpp/physics/physics/rrtmgp_lw_cloud_sampling.F90' ,
+    'FV3/ccpp/physics/physics/rrtmgp_sw_cloud_sampling.F90' ,
+    'FV3/ccpp/physics/physics/GFS_cloud_diagnostics.F90'           ,
+    'FV3/ccpp/physics/physics/mo_cloud_sampling.F90'               ,
+    'FV3/ccpp/physics/physics/GFS_rrtmgp_gfdlmp_pre.F90'           ,
+    'FV3/ccpp/physics/physics/GFS_rrtmgp_zhaocarr_pre.F90'         ,
+    'FV3/ccpp/physics/physics/GFS_rrtmgp_sw_post.F90'
     ]
 
 # Default build dir, relative to current working directory,
@@ -356,20 +360,6 @@ SUITES_DIR = 'FV3/ccpp/suites'
 # if no entry is made here. Possible values are: 'all', 'none',
 # or a list of standard_names: [ 'var1', 'var3' ].
 OPTIONAL_ARGUMENTS = {
-    'rrtmgp_sw_rte' : {
-         'rrtmgp_sw_rte_run' : [
-             'components_of_surface_downward_shortwave_fluxes',
-             ],
-         },
-    'GFS_rrtmgp_sw_post' : {
-         'GFS_rrtmgp_sw_post_run' : 'none',
-         },
-    'rrtmgp_lw_rte' : {
-         'rrtmgp_lw_rte_run' : 'none',
-        },
-    'GFS_rrtmgp_lw_post' : {
-         'GFS_rrtmgp_lw_post_run' : 'none',
-         },
     'rrtmg_sw' : {
         'rrtmg_sw_run' : [
             'tendency_of_air_temperature_due_to_shortwave_heating_assuming_clear_sky_on_radiation_time_step_and_radiation_levels',
@@ -430,7 +420,34 @@ OPTIONAL_ARGUMENTS = {
             'rime_factor',
             ],
         },
-
+    'rrtmgp_lw_rte' : {
+         'rrtmgp_lw_rte_run' : [
+             'RRTMGP_jacobian_of_lw_flux_profile_upward',
+             'RRTMGP_jacobian_of_lw_flux_profile_downward',
+             ],
+         },          
+    'rrtmgp_sw_rte' : {
+         'rrtmgp_sw_rte_run' : [
+             'components_of_surface_downward_shortwave_fluxes',
+             ],
+         },        
+    'GFS_rrtmgp_sw_post' : {
+         'GFS_rrtmgp_sw_post_run' : [
+             'tendency_of_air_temperature_due_to_shortwave_heating_assuming_clear_sky_on_radiation_time_step',
+             'components_of_surface_downward_shortwave_fluxes',
+             ],
+         },
+    'GFS_rrtmgp_lw_post' : {
+         'GFS_rrtmgp_lw_post_run' : [
+             'tendency_of_air_temperature_due_to_longwave_heating_assuming_clear_sky_on_radiation_time_step',
+             ],
+         },
+    'GFS_suite_interstitial_2' : {
+         'GFS_suite_interstitial_2_run' : [
+             'RRTMGP_jacobian_of_lw_flux_profile_upward',
+             'RRTMGP_lw_flux_profile_upward_allsky',
+             ],
+         },  
     #'subroutine_name_1' : 'all',
     #'subroutine_name_2' : 'none',
     #'subroutine_name_2' : [ 'var1', 'var3'],

--- a/ccpp/config/ccpp_prebuild_config.py
+++ b/ccpp/config/ccpp_prebuild_config.py
@@ -294,6 +294,7 @@ SCHEME_FILES = [
     'FV3/ccpp/physics/physics/sfc_nst.f',
     'FV3/ccpp/physics/physics/sfc_ocean.F',
     'FV3/ccpp/physics/physics/sfc_sice.f',
+    'FV3/ccpp/physics/physics/tracer_sanitizer.F90',
     # HAFSFER_HIRES
     'FV3/ccpp/physics/physics/mp_fer_hires.F90',
     # RRTMGP

--- a/ccpp/suites/suite_FV3_GFS_v15p2_RRTMGP.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15p2_RRTMGP.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_RRTMGP" lib="ccppphys" ver="4">
+<suite name="FV3_GFS_v15p2_RRTMGP" lib="ccppphys" ver="4">
   <!-- <init></init> -->
+  <group name="fast_physics">
+    <subcycle loop="1">
+      <scheme>fv_sat_adj</scheme>
+    </subcycle>
+  </group>
   <group name="time_vary">
     <subcycle loop="1">
       <scheme>GFS_time_vary_pre</scheme>
@@ -14,6 +19,8 @@
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmgp_pre</scheme>
+      <scheme>GFS_rrtmgp_gfdlmp_pre</scheme>
+      <scheme>GFS_cloud_diagnostics</scheme>
       <scheme>GFS_rrtmgp_sw_pre</scheme>
       <scheme>rrtmgp_sw_gas_optics</scheme>
       <scheme>rrtmgp_sw_aerosol_optics</scheme>
@@ -68,7 +75,8 @@
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>rayleigh_damp</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
-      <scheme>ozphys</scheme>
+      <scheme>ozphys_2015</scheme>
+      <scheme>h2ophys</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>
@@ -80,8 +88,7 @@
       <scheme>GFS_suite_interstitial_4</scheme>
       <scheme>cnvc90</scheme>
       <scheme>GFS_MP_generic_pre</scheme>
-      <scheme>zhaocarr_gscond</scheme>
-      <scheme>zhaocarr_precpd</scheme>
+      <scheme>gfdl_cloud_microphys</scheme>
       <scheme>GFS_MP_generic_post</scheme>
       <scheme>maximum_hourly_diagnostics</scheme>
     </subcycle>
@@ -89,6 +96,7 @@
   <group name="stochastics">
     <subcycle loop="1">
       <scheme>GFS_stochastics</scheme>
+      <scheme>phys_tend</scheme>
     </subcycle>
   </group>
   <!-- <finalize></finalize> -->

--- a/ccpp/suites/suite_FV3_GFS_v16beta_RRTMGP.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16beta_RRTMGP.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<suite name="FV3_GFS_v16beta_RRTMGP" lib="ccppphys" ver="4">
+  <!-- <init></init> -->
+  <group name="fast_physics">
+    <subcycle loop="1">
+      <scheme>fv_sat_adj</scheme>
+    </subcycle>
+  </group>
+  <group name="time_vary">
+    <subcycle loop="1">
+      <scheme>GFS_time_vary_pre</scheme>
+      <scheme>GFS_rrtmgp_setup</scheme>
+      <scheme>GFS_rad_time_vary</scheme>
+      <scheme>GFS_phys_time_vary</scheme>
+    </subcycle>
+  </group>
+  <group name="radiation">
+    <subcycle loop="1">
+      <scheme>GFS_suite_interstitial_rad_reset</scheme>
+      <scheme>GFS_rrtmgp_pre</scheme>
+      <scheme>GFS_rrtmgp_gfdlmp_pre</scheme>
+      <scheme>GFS_cloud_diagnostics</scheme>
+      <scheme>GFS_rrtmgp_sw_pre</scheme>
+      <scheme>rrtmgp_sw_gas_optics</scheme>
+      <scheme>rrtmgp_sw_aerosol_optics</scheme>
+      <scheme>rrtmgp_sw_cloud_optics</scheme>
+      <scheme>rrtmgp_sw_cloud_sampling</scheme>
+      <scheme>rrtmgp_sw_rte</scheme>
+      <scheme>GFS_rrtmgp_sw_post</scheme>
+      <scheme>rrtmgp_lw_pre</scheme>
+      <scheme>rrtmgp_lw_gas_optics</scheme>
+      <scheme>rrtmgp_lw_aerosol_optics</scheme>
+      <scheme>rrtmgp_lw_cloud_optics</scheme>
+      <scheme>rrtmgp_lw_cloud_sampling</scheme>
+      <scheme>rrtmgp_lw_rte</scheme>
+      <scheme>GFS_rrtmgp_lw_post</scheme>
+    </subcycle>
+  </group>
+  <group name="physics">
+    <subcycle loop="1">
+      <scheme>GFS_suite_interstitial_phys_reset</scheme>
+      <scheme>GFS_suite_stateout_reset</scheme>
+      <scheme>get_prs_fv3</scheme>
+      <scheme>GFS_suite_interstitial_1</scheme>
+      <scheme>GFS_surface_generic_pre</scheme>
+      <scheme>GFS_surface_composites_pre</scheme>
+      <scheme>dcyc2t3</scheme>
+      <scheme>GFS_surface_composites_inter</scheme>
+      <scheme>GFS_suite_interstitial_2</scheme>
+    </subcycle>
+    <!-- Surface iteration loop -->
+    <subcycle loop="2">
+      <scheme>sfc_diff</scheme>
+      <scheme>GFS_surface_loop_control_part1</scheme>
+      <scheme>sfc_nst_pre</scheme>
+      <scheme>sfc_nst</scheme>
+      <scheme>sfc_nst_post</scheme>
+      <scheme>lsm_noah</scheme>
+      <scheme>sfc_sice</scheme>
+      <scheme>GFS_surface_loop_control_part2</scheme>
+    </subcycle>
+    <!-- End of surface iteration loop -->
+    <subcycle loop="1">
+      <scheme>GFS_surface_composites_post</scheme>
+      <scheme>sfc_diag</scheme>
+      <scheme>sfc_diag_post</scheme>
+      <scheme>GFS_surface_generic_post</scheme>
+      <scheme>GFS_PBL_generic_pre</scheme>
+      <scheme>satmedmfvdifq</scheme>
+      <scheme>GFS_PBL_generic_post</scheme>
+      <scheme>GFS_GWD_generic_pre</scheme>
+      <scheme>cires_ugwp</scheme>
+      <scheme>cires_ugwp_post</scheme>
+      <scheme>GFS_GWD_generic_post</scheme>
+      <scheme>rayleigh_damp</scheme>
+      <scheme>GFS_suite_stateout_update</scheme>
+      <scheme>ozphys_2015</scheme>
+      <scheme>h2ophys</scheme>
+      <scheme>get_phi_fv3</scheme>
+      <scheme>GFS_suite_interstitial_3</scheme>
+      <scheme>GFS_DCNV_generic_pre</scheme>
+      <scheme>samfdeepcnv</scheme>
+      <scheme>GFS_DCNV_generic_post</scheme>
+      <scheme>GFS_SCNV_generic_pre</scheme>
+      <scheme>samfshalcnv</scheme>
+      <scheme>GFS_SCNV_generic_post</scheme>
+      <scheme>GFS_suite_interstitial_4</scheme>
+      <scheme>cnvc90</scheme>
+      <scheme>GFS_MP_generic_pre</scheme>
+      <scheme>gfdl_cloud_microphys</scheme>
+      <scheme>GFS_MP_generic_post</scheme>
+      <scheme>maximum_hourly_diagnostics</scheme>
+    </subcycle>
+  </group>
+  <group name="stochastics">
+    <subcycle loop="1">
+      <scheme>GFS_stochastics</scheme>
+      <scheme>phys_tend</scheme>
+    </subcycle>
+  </group>
+  <!-- <finalize></finalize> -->
+</suite>

--- a/ccpp/suites/suite_FV3_GSD_noah.xml
+++ b/ccpp/suites/suite_FV3_GSD_noah.xml
@@ -79,6 +79,7 @@
       <scheme>mp_thompson_post</scheme>
       <scheme>GFS_MP_generic_post</scheme>
       <scheme>cu_gf_driver_post</scheme>
+      <scheme>tracer_sanitizer</scheme>
       <scheme>maximum_hourly_diagnostics</scheme>
     </subcycle>
   </group>

--- a/ccpp/suites/suite_FV3_GSD_v0.xml
+++ b/ccpp/suites/suite_FV3_GSD_v0.xml
@@ -81,7 +81,7 @@
       <scheme>mp_thompson_post</scheme>
       <scheme>GFS_MP_generic_post</scheme>
       <scheme>cu_gf_driver_post</scheme>
-      <scheme>tracer_sanitizer</scheme>
+      <!-- <scheme>tracer_sanitizer</scheme> -->
       <scheme>maximum_hourly_diagnostics</scheme>
     </subcycle>
   </group>

--- a/ccpp/suites/suite_FV3_GSD_v0.xml
+++ b/ccpp/suites/suite_FV3_GSD_v0.xml
@@ -81,6 +81,7 @@
       <scheme>mp_thompson_post</scheme>
       <scheme>GFS_MP_generic_post</scheme>
       <scheme>cu_gf_driver_post</scheme>
+      <scheme>tracer_sanitizer</scheme>
       <scheme>maximum_hourly_diagnostics</scheme>
     </subcycle>
   </group>

--- a/gfsphysics/CMakeLists.txt
+++ b/gfsphysics/CMakeLists.txt
@@ -17,7 +17,6 @@ endif()
 set(CCPP_SOURCES
     physics/mersenne_twister.f
     physics/namelist_soilveg.f
-    physics/physparam.f
     physics/set_soilveg.f
 
     physics/noahmp_tables.f90

--- a/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -9,7 +9,7 @@ module GFS_typedefs
                                            con_t0c, con_cvap, con_cliq, con_eps, con_epsq, &
                                            con_epsm1, con_ttp, rlapse, con_jcal, con_rhw0, &
                                            con_sbc, con_tice, cimin, con_p0, rhowater,     &
-                                           con_csol
+                                           con_csol, con_epsqs
 
        use module_radsw_parameters,  only: topfsw_type, sfcfsw_type, profsw_type, cmpfsw_type, NBDSW
        use module_radlw_parameters,  only: topflw_type, sfcflw_type, proflw_type, NBDLW
@@ -680,26 +680,26 @@ module GFS_typedefs
     logical              :: swhtr           !< flag to output sw heating rate (Radtend%swhc)
 #ifdef CCPP
     ! RRTMGP
-    logical              :: do_RRTMGP         !< Use RRTMGP
-    character(len=128)   :: active_gases      !< Character list of active gases used in RRTMGP
-    integer              :: nGases            !< Number of active gases
-    character(len=128)   :: rrtmgp_root       !< Directory of rte+rrtmgp source code
-    character(len=128)   :: lw_file_gas       !< RRTMGP K-distribution file, coefficients to compute optics for gaseous atmosphere
-    character(len=128)   :: lw_file_clouds    !< RRTMGP file containing coefficients used to compute clouds optical properties
-    integer              :: rrtmgp_nBandsLW   !< Number of RRTMGP LW bands.
-    integer              :: rrtmgp_nGptsLW    !< Number of RRTMGP LW spectral points.
-    character(len=128)   :: sw_file_gas       !< RRTMGP K-distribution file, coefficients to compute optics for gaseous atmosphere
-    character(len=128)   :: sw_file_clouds    !< RRTMGP file containing coefficients used to compute clouds optical properties
-    integer              :: rrtmgp_nBandsSW   !< Number of RRTMGP SW bands.
-    integer              :: rrtmgp_nGptsSW    !< Number of RRTMGP SW spectral points.
-    integer              :: rrtmgp_cld_optics !< Flag to control which RRTMGP routine to compute cloud-optics.
-                                                 !< = 0 ; Use RRTMG implementation
-                                                 !< = 1 ; Use RRTMGP (pade)
-                                                 !< = 2 ; USE RRTMGP (LUT)
-    integer              :: rrtmgp_nrghice    !< Number of ice-roughness categories
-    integer              :: rrtmgp_nGauss_ang !< Number of angles used in Gaussian quadrature
-    logical              :: do_GPsw_Glw       ! If set to true use rrtmgp for SW calculation, rrtmg for LW.
-    character(len=128)   :: active_gases_array(100)          !< character array for each trace gas name 
+    logical              :: do_RRTMGP               !< Use RRTMGP
+    character(len=128)   :: active_gases            !< Character list of active gases used in RRTMGP
+    integer              :: nGases                  !< Number of active gases
+    character(len=128)   :: rrtmgp_root             !< Directory of rte+rrtmgp source code
+    character(len=128)   :: lw_file_gas             !< RRTMGP K-distribution file, coefficients to compute optics for gaseous atmosphere
+    character(len=128)   :: lw_file_clouds          !< RRTMGP file containing coefficients used to compute clouds optical properties
+    integer              :: rrtmgp_nBandsLW         !< Number of RRTMGP LW bands.
+    integer              :: rrtmgp_nGptsLW          !< Number of RRTMGP LW spectral points.
+    character(len=128)   :: sw_file_gas             !< RRTMGP K-distribution file, coefficients to compute optics for gaseous atmosphere
+    character(len=128)   :: sw_file_clouds          !< RRTMGP file containing coefficients used to compute clouds optical properties
+    integer              :: rrtmgp_nBandsSW         !< Number of RRTMGP SW bands.
+    integer              :: rrtmgp_nGptsSW          !< Number of RRTMGP SW spectral points.
+    logical              :: doG_cldoptics           !< Use legacy RRTMG cloud-optics?                                             
+    logical              :: doGP_cldoptics_PADE     !< Use RRTMGP cloud-optics: PADE approximation?                                             
+    logical              :: doGP_cldoptics_LUT      !< Use RRTMGP cloud-optics: LUTs?                                             
+    integer              :: rrtmgp_nrghice          !< Number of ice-roughness categories
+    integer              :: rrtmgp_nGauss_ang       !< Number of angles used in Gaussian quadrature
+    logical              :: do_GPsw_Glw             !< If set to true use rrtmgp for SW calculation, rrtmg for LW.
+    character(len=128)   :: active_gases_array(100) !< character array for each trace gas name
+    logical              :: use_LW_jacobian         !< If true, use Jacobian of LW to update radiation tendency.
 #endif
 !--- microphysical switch
     integer              :: ncld            !< choice of cloud scheme
@@ -1979,67 +1979,74 @@ module GFS_typedefs
 
 #ifdef CCPP
     ! RRTMGP
-    integer                             :: ipsdlw0                           !<
-    integer                             :: ipsdsw0                           !<
-    real (kind=kind_phys), pointer      :: p_lay(:,:)             => null()  !<
-    real (kind=kind_phys), pointer      :: p_lev(:,:)             => null()  !<
-    real (kind=kind_phys), pointer      :: t_lev(:,:)             => null()  !<
-    real (kind=kind_phys), pointer      :: t_lay(:,:)             => null()  !<
-    real (kind=kind_phys), pointer      :: relhum(:,:)            => null()  !<
-    real (kind=kind_phys), pointer      :: tv_lay(:,:)            => null()  !<
-    real (kind=kind_phys), pointer      :: tracer(:,:,:)          => null()  !<
-    real (kind=kind_phys), pointer      :: aerosolslw(:,:,:,:)    => null()  !< Aerosol radiative properties in each LW band.
-    real (kind=kind_phys), pointer      :: aerosolssw(:,:,:,:)    => null()  !< Aerosol radiative properties in each SW band.
-    real (kind=kind_phys), pointer      :: cld_frac(:,:)          => null()  !< Total cloud fraction
-    real (kind=kind_phys), pointer      :: cld_lwp(:,:)           => null()  !< Cloud liquid water path
-    real (kind=kind_phys), pointer      :: cld_reliq(:,:)         => null()  !< Cloud liquid effective radius
-    real (kind=kind_phys), pointer      :: cld_iwp(:,:)           => null()  !< Cloud ice water path
-    real (kind=kind_phys), pointer      :: cld_reice(:,:)         => null()  !< Cloud ice effecive radius
-    real (kind=kind_phys), pointer      :: cld_swp(:,:)           => null()  !< Cloud snow water path
-    real (kind=kind_phys), pointer      :: cld_resnow(:,:)        => null()  !< Cloud snow effective radius
-    real (kind=kind_phys), pointer      :: cld_rwp(:,:)           => null()  !< Cloud rain water path
-    real (kind=kind_phys), pointer      :: cld_rerain(:,:)        => null()  !< Cloud rain effective radius
-    real (kind=kind_phys), pointer      :: hsw0(:,:)              => null()  !< RRTMGP shortwave heating-rate (clear-sky)
-    real (kind=kind_phys), pointer      :: hswc(:,:)              => null()  !< RRTMGP shortwave heating-rate (all-sky)
-    real (kind=kind_phys), pointer      :: hswb(:,:,:)            => null()  !< RRTMGP shortwave heating-rate (all-sky), by band
-    real (kind=kind_phys), pointer      :: hlw0(:,:)              => null()  !< RRTMGP longwave heating-rate (clear-sky)
-    real (kind=kind_phys), pointer      :: hlwc(:,:)              => null()  !< RRTMGP longwave heating-rate (all-sky)
-    real (kind=kind_phys), pointer      :: hlwb(:,:,:)            => null()  !< RRTMGP longwave heating-rate (all-sky), by band
-    real (kind=kind_phys), pointer      :: fluxlwUP_allsky(:,:)   => null()  !< RRTMGP upward   longwave  all-sky flux profile
-    real (kind=kind_phys), pointer      :: fluxlwDOWN_allsky(:,:) => null()  !< RRTMGP downward longwave  all-sky flux profile
-    real (kind=kind_phys), pointer      :: fluxlwUP_clrsky(:,:)   => null()  !< RRTMGP upward   longwave  clr-sky flux profile
-    real (kind=kind_phys), pointer      :: fluxlwDOWN_clrsky(:,:) => null()  !< RRTMGP downward longwave  clr-sky flux profile
-    real (kind=kind_phys), pointer      :: fluxswUP_allsky(:,:)   => null()  !< RRTMGP upward   shortwave all-sky flux profile
-    real (kind=kind_phys), pointer      :: fluxswDOWN_allsky(:,:) => null()  !< RRTMGP downward shortwave all-sky flux profile
-    real (kind=kind_phys), pointer      :: fluxswUP_clrsky(:,:)   => null()  !< RRTMGP upward   shortwave clr-sky flux profile
-    real (kind=kind_phys), pointer      :: fluxswDOWN_clrsky(:,:) => null()  !< RRTMGP downward shortwave clr-sky flux profile
-    real (kind=kind_phys), pointer      :: sfc_emiss_byband(:,:)  => null()  !<
-    real (kind=kind_phys), pointer      :: sec_diff_byband(:,:)   => null()  !<
-    real (kind=kind_phys), pointer      :: sfc_alb_nir_dir(:,:)   => null()  !<
-    real (kind=kind_phys), pointer      :: sfc_alb_nir_dif(:,:)   => null()  !<
-    real (kind=kind_phys), pointer      :: sfc_alb_uvvis_dir(:,:) => null()  !<
-    real (kind=kind_phys), pointer      :: sfc_alb_uvvis_dif(:,:) => null()  !<
-    real (kind=kind_phys), pointer      :: toa_src_lw(:,:)        => null()  !<
-    real (kind=kind_phys), pointer      :: toa_src_sw(:,:)        => null()  !<
-    character(len=128),    pointer      :: active_gases_array(:)  => null()  !< Character array for each trace gas name
-    integer, pointer                    :: icseed_lw(:)           => null()  !< RRTMGP seed for RNG for longwave radiation
-    integer, pointer                    :: icseed_sw(:)           => null()  !< RRTMGP seed for RNG for shortwave radiation
-    type(proflw_type), pointer          :: flxprf_lw(:,:)         => null()  !< DDT containing RRTMGP longwave fluxes
-    type(profsw_type), pointer          :: flxprf_sw(:,:)         => null()  !< DDT containing RRTMGP shortwave fluxes
-    type(ty_gas_optics_rrtmgp)          :: lw_gas_props                      !< RRTMGP DDT
-    type(ty_gas_optics_rrtmgp)          :: sw_gas_props                      !< RRTMGP DDT
-    type(ty_cloud_optics)               :: lw_cloud_props                    !< RRTMGP DDT
-    type(ty_cloud_optics)               :: sw_cloud_props                    !< RRTMGP DDT
-    type(ty_optical_props_1scl)         :: lw_optical_props_cloudsByBand     !< RRTMGP DDT
-    type(ty_optical_props_1scl)         :: lw_optical_props_clouds           !< RRTMGP DDT
-    type(ty_optical_props_1scl)         :: lw_optical_props_clrsky           !< RRTMGP DDT
-    type(ty_optical_props_1scl)         :: lw_optical_props_aerosol          !< RRTMGP DDT
-    type(ty_optical_props_2str)         :: sw_optical_props_cloudsByBand     !< RRTMGP DDT
-    type(ty_optical_props_2str)         :: sw_optical_props_clouds           !< RRTMGP DDT
-    type(ty_optical_props_2str)         :: sw_optical_props_clrsky           !< RRTMGP DDT
-    type(ty_optical_props_2str)         :: sw_optical_props_aerosol          !< RRTMGP DDT
-    type(ty_gas_concs)                  :: gas_concentrations                !< RRTMGP DDT
-    type(ty_source_func_lw)             :: sources                           !< RRTMGP DDT
+    integer                             :: ipsdlw0                              !<
+    integer                             :: ipsdsw0                              !<
+    real (kind=kind_phys), pointer      :: sktp1r(:)                 => null()  !<
+    real (kind=kind_phys), pointer      :: p_lay(:,:)                => null()  !<
+    real (kind=kind_phys), pointer      :: p_lev(:,:)                => null()  !<
+    real (kind=kind_phys), pointer      :: t_lev(:,:)                => null()  !<
+    real (kind=kind_phys), pointer      :: t_lay(:,:)                => null()  !<
+    real (kind=kind_phys), pointer      :: relhum(:,:)               => null()  !<
+    real (kind=kind_phys), pointer      :: tv_lay(:,:)               => null()  !<
+    real (kind=kind_phys), pointer      :: qs_lay(:,:)               => null()  !<
+    real (kind=kind_phys), pointer      :: q_lay(:,:)                => null()  !<
+    real (kind=kind_phys), pointer      :: deltaZ(:,:)               => null()  !<
+    real (kind=kind_phys), pointer      :: cloud_overlap_param(:,:)  => null()  !< Cloud overlap parameter
+    real (kind=kind_phys), pointer      :: precip_overlap_param(:,:) => null()  !< Precipitation overlap parameter
+    real (kind=kind_phys), pointer      :: tracer(:,:,:)             => null()  !<
+    real (kind=kind_phys), pointer      :: aerosolslw(:,:,:,:)       => null()  !< Aerosol radiative properties in each LW band.
+    real (kind=kind_phys), pointer      :: aerosolssw(:,:,:,:)       => null()  !< Aerosol radiative properties in each SW band.
+    real (kind=kind_phys), pointer      :: cld_frac(:,:)             => null()  !< Total cloud fraction
+    real (kind=kind_phys), pointer      :: cld_lwp(:,:)              => null()  !< Cloud liquid water path
+    real (kind=kind_phys), pointer      :: cld_reliq(:,:)            => null()  !< Cloud liquid effective radius
+    real (kind=kind_phys), pointer      :: cld_iwp(:,:)              => null()  !< Cloud ice water path
+    real (kind=kind_phys), pointer      :: cld_reice(:,:)            => null()  !< Cloud ice effecive radius
+    real (kind=kind_phys), pointer      :: cld_swp(:,:)              => null()  !< Cloud snow water path
+    real (kind=kind_phys), pointer      :: cld_resnow(:,:)           => null()  !< Cloud snow effective radius
+    real (kind=kind_phys), pointer      :: cld_rwp(:,:)              => null()  !< Cloud rain water path
+    real (kind=kind_phys), pointer      :: cld_rerain(:,:)           => null()  !< Cloud rain effective radius
+    real (kind=kind_phys), pointer      :: precip_frac(:,:)          => null()  !< Precipitation fraction
+    real (kind=kind_phys), pointer      :: fluxlwUP_allsky(:,:)      => null()  !< RRTMGP upward   longwave  all-sky flux profile
+    real (kind=kind_phys), pointer      :: fluxlwDOWN_allsky(:,:)    => null()  !< RRTMGP downward longwave  all-sky flux profile
+    real (kind=kind_phys), pointer      :: fluxlwUP_clrsky(:,:)      => null()  !< RRTMGP upward   longwave  clr-sky flux profile
+    real (kind=kind_phys), pointer      :: fluxlwDOWN_clrsky(:,:)    => null()  !< RRTMGP downward longwave  clr-sky flux profile
+    real (kind=kind_phys), pointer      :: fluxswUP_allsky(:,:)      => null()  !< RRTMGP upward   shortwave all-sky flux profile
+    real (kind=kind_phys), pointer      :: fluxswDOWN_allsky(:,:)    => null()  !< RRTMGP downward shortwave all-sky flux profile
+    real (kind=kind_phys), pointer      :: fluxswUP_clrsky(:,:)      => null()  !< RRTMGP upward   shortwave clr-sky flux profile
+    real (kind=kind_phys), pointer      :: fluxswDOWN_clrsky(:,:)    => null()  !< RRTMGP downward shortwave clr-sky flux profile
+    real (kind=kind_phys), pointer      :: fluxlwUP_jac(:,:)         => null()  !< RRTMGP upward Jacobian of longwave flux
+    real (kind=kind_phys), pointer      :: fluxlwDOWN_jac(:,:)       => null()  !< RRTMGP downward Jacobian of longwave flux 
+    real (kind=kind_phys), pointer      :: sfc_emiss_byband(:,:)     => null()  !<
+    real (kind=kind_phys), pointer      :: sec_diff_byband(:,:)      => null()  !<
+    real (kind=kind_phys), pointer      :: sfc_alb_nir_dir(:,:)      => null()  !<
+    real (kind=kind_phys), pointer      :: sfc_alb_nir_dif(:,:)      => null()  !<
+    real (kind=kind_phys), pointer      :: sfc_alb_uvvis_dir(:,:)    => null()  !<
+    real (kind=kind_phys), pointer      :: sfc_alb_uvvis_dif(:,:)    => null()  !<
+    real (kind=kind_phys), pointer      :: toa_src_lw(:,:)           => null()  !<
+    real (kind=kind_phys), pointer      :: toa_src_sw(:,:)           => null()  !<
+    character(len=128),    pointer      :: active_gases_array(:)     => null()  !< Character array for each trace gas name
+    integer, pointer                    :: icseed_lw(:)              => null()  !< RRTMGP seed for RNG for longwave radiation
+    integer, pointer                    :: icseed_sw(:)              => null()  !< RRTMGP seed for RNG for shortwave radiation
+    type(proflw_type), pointer          :: flxprf_lw(:,:)            => null()  !< DDT containing RRTMGP longwave fluxes
+    type(profsw_type), pointer          :: flxprf_sw(:,:)            => null()  !< DDT containing RRTMGP shortwave fluxes
+    type(ty_gas_optics_rrtmgp)          :: lw_gas_props                         !< RRTMGP DDT
+    type(ty_gas_optics_rrtmgp)          :: sw_gas_props                         !< RRTMGP DDT
+    type(ty_cloud_optics)               :: lw_cloud_props                       !< RRTMGP DDT
+    type(ty_cloud_optics)               :: sw_cloud_props                       !< RRTMGP DDT
+    type(ty_optical_props_1scl)         :: lw_optical_props_cloudsByBand        !< RRTMGP DDT
+    type(ty_optical_props_1scl)         :: lw_optical_props_clouds              !< RRTMGP DDT
+    type(ty_optical_props_1scl)         :: lw_optical_props_precipByBand        !< RRTMGP DDT
+    type(ty_optical_props_1scl)         :: lw_optical_props_precip              !< RRTMGP DDT
+    type(ty_optical_props_1scl)         :: lw_optical_props_clrsky              !< RRTMGP DDT
+    type(ty_optical_props_1scl)         :: lw_optical_props_aerosol             !< RRTMGP DDT
+    type(ty_optical_props_2str)         :: sw_optical_props_cloudsByBand        !< RRTMGP DDT
+    type(ty_optical_props_2str)         :: sw_optical_props_clouds              !< RRTMGP DDT
+    type(ty_optical_props_2str)         :: sw_optical_props_precipByBand        !< RRTMGP DDT
+    type(ty_optical_props_2str)         :: sw_optical_props_precip              !< RRTMGP DDT
+    type(ty_optical_props_2str)         :: sw_optical_props_clrsky              !< RRTMGP DDT
+    type(ty_optical_props_2str)         :: sw_optical_props_aerosol             !< RRTMGP DDT
+    type(ty_gas_concs)                  :: gas_concentrations                   !< RRTMGP DDT
+    type(ty_source_func_lw)             :: sources                              !< RRTMGP DDT
 #endif
 
     !-- HWRF physics: dry mixing ratios
@@ -2963,13 +2970,13 @@ module GFS_typedefs
     character(len=128)   :: sw_file_clouds  = ''             !< RRTMGP file containing coefficients used to compute clouds optical properties
     integer              :: rrtmgp_nBandsSW = 14             !< Number of RRTMGP SW bands.
     integer              :: rrtmgp_nGptsSW  = 224            !< Number of RRTMGP SW spectral points.
-    integer              :: rrtmgp_cld_optics = 0            !<  Flag to control which RRTMGP routine to compute cloud-optics.
-                                                             !< = 0 ; Use RRTMGP implementation
-                                                             !< = 1 ; Use RRTMGP (pade)
-                                                             !< = 2 ; USE RRTMGP (LUT)
+    logical              :: doG_cldoptics       = .false.    !< Use legacy RRTMG cloud-optics?                                             
+    logical              :: doGP_cldoptics_PADE = .false.    !< Use RRTMGP cloud-optics: PADE approximation?
+    logical              :: doGP_cldoptics_LUT  = .false.    !< Use RRTMGP cloud-optics: LUTs?     
     integer              :: rrtmgp_nrghice = 0               !< Number of ice-roughness categories
     integer              :: rrtmgp_nGauss_ang=1              !< Number of angles used in Gaussian quadrature
-    logical              :: do_GPsw_Glw    = .false.         
+    logical              :: do_GPsw_Glw    = .false.     
+    logical              :: use_LW_jacobian = .false.        !< Use Jacobian of LW to update LW radiation tendencies. 
 #endif
 !--- Z-C microphysical parameters
     integer              :: ncld              =  1                 !< choice of cloud scheme
@@ -3331,8 +3338,9 @@ module GFS_typedefs
                                do_RRTMGP, active_gases, nGases, rrtmgp_root,                &
                                lw_file_gas, lw_file_clouds, rrtmgp_nBandsLW, rrtmgp_nGptsLW,&
                                sw_file_gas, sw_file_clouds, rrtmgp_nBandsSW, rrtmgp_nGptsSW,&
-                               rrtmgp_cld_optics, rrtmgp_nrghice, rrtmgp_nGauss_ang,        &
-                               do_GPsw_Glw,                                                 &
+                               doG_cldoptics, doGP_cldoptics_PADE, doGP_cldoptics_LUT,      &
+                               rrtmgp_nrghice, rrtmgp_nGauss_ang, do_GPsw_Glw,              &
+                               use_LW_jacobian,                                             &
 #endif
                           ! IN CCN forcing
                                iccn,                                                        &
@@ -3696,7 +3704,10 @@ module GFS_typedefs
     Model%sw_file_clouds    = sw_file_clouds
     Model%rrtmgp_nBandsSW   = rrtmgp_nBandsSW
     Model%rrtmgp_nGptsSW    = rrtmgp_nGptsSW
-    Model%rrtmgp_cld_optics = RRTMGP_CLD_OPTICS
+    Model%doG_cldoptics       = doG_cldoptics
+    Model%doGP_cldoptics_PADE = doGP_cldoptics_PADE
+    Model%doGP_cldoptics_LUT  = doGP_cldoptics_LUT
+    Model%use_LW_jacobian     = use_LW_jacobian
     ! RRTMGP incompatible with levr /= levs
     if (Model%do_RRTMGP .and. Model%levr /= Model%levs) then
       write(0,*) "Logic error, RRTMGP only works with levr = levs"
@@ -4854,7 +4865,10 @@ module GFS_typedefs
         print *, ' sw_file_clouds     : ', Model%sw_file_clouds
         print *, ' rrtmgp_nBandsSW    : ', Model%rrtmgp_nBandsSW
         print *, ' rrtmgp_nGptsSW     : ', Model%rrtmgp_nGptsSW
-        print *, ' rrtmgp_cld_optics  : ', Model%rrtmgp_cld_optics
+        print *, ' doG_cldoptics      : ', Model%doG_cldoptics
+        print *, ' doGP_cldoptics_PADE: ', Model%doGP_cldoptics_PADE
+        print *, ' doGP_cldoptics_LUT : ', Model%doGP_cldoptics_LUT
+        print *, ' use_LW_jacobian    : ', Model%use_LW_jacobian
       endif
 #endif
       print *, ' '
@@ -6373,53 +6387,57 @@ module GFS_typedefs
     allocate (Interstitial%zorl_land       (IM))
     allocate (Interstitial%zorl_ocean      (IM))
     allocate (Interstitial%zt1d            (IM))
-   ! RRTMGP
+
+    ! RRTMGP
+    allocate (Interstitial%fluxlwDOWN_jac       (IM, Model%levs+1))
+    allocate (Interstitial%fluxlwUP_jac         (IM, Model%levs+1))
+    allocate (Interstitial%sktp1r               (IM))
+    allocate (Interstitial%fluxlwUP_allsky      (IM, Model%levs+1))
     if (Model%do_RRTMGP) then
-      allocate (Interstitial%tracer            (IM, Model%levs,Model%ntrac))
-      allocate (Interstitial%tv_lay            (IM, Model%levs))
-      allocate (Interstitial%relhum            (IM, Model%levs))
-      allocate (Interstitial%p_lev             (IM, Model%levs+1))
-      allocate (Interstitial%p_lay             (IM, Model%levs))
-      allocate (Interstitial%t_lev             (IM, Model%levs+1))
-      allocate (Interstitial%t_lay             (IM, Model%levs))
-      allocate (Interstitial%fluxlwUP_allsky   (IM, Model%levs+1))
-      allocate (Interstitial%fluxlwDOWN_allsky (IM, Model%levs+1))
-      allocate (Interstitial%fluxlwUP_clrsky   (IM, Model%levs+1))
-      allocate (Interstitial%fluxlwDOWN_clrsky (IM, Model%levs+1))
-      allocate (Interstitial%fluxswUP_allsky   (IM, Model%levs+1))
-      allocate (Interstitial%fluxswDOWN_allsky (IM, Model%levs+1))
-      allocate (Interstitial%fluxswUP_clrsky   (IM, Model%levs+1))
-      allocate (Interstitial%fluxswDOWN_clrsky (IM, Model%levs+1))
-      allocate (Interstitial%aerosolslw        (IM, Model%levs, Model%rrtmgp_nBandsLW, NF_AELW))
-      allocate (Interstitial%aerosolssw        (IM, Model%levs, Model%rrtmgp_nBandsSW, NF_AESW))
-      allocate (Interstitial%cld_frac          (IM, Model%levs))
-      allocate (Interstitial%cld_lwp           (IM, Model%levs))
-      allocate (Interstitial%cld_reliq         (IM, Model%levs))
-      allocate (Interstitial%cld_iwp           (IM, Model%levs))
-      allocate (Interstitial%cld_reice         (IM, Model%levs))
-      allocate (Interstitial%cld_swp           (IM, Model%levs))
-      allocate (Interstitial%cld_resnow        (IM, Model%levs))
-      allocate (Interstitial%cld_rwp           (IM, Model%levs))
-      allocate (Interstitial%cld_rerain        (IM, Model%levs))
-      allocate (Interstitial%hsw0              (IM, Model%levs))
-      allocate (Interstitial%hswc              (IM, Model%levs))
-      allocate (Interstitial%hswb              (IM, Model%levs, Model%rrtmgp_nGptsSW))
-      allocate (Interstitial%hlw0              (IM, Model%levs))
-      allocate (Interstitial%hlwc              (IM, Model%levs))
-      allocate (Interstitial%hlwb              (IM, Model%levs, Model%rrtmgp_nGptsLW))
-      allocate (Interstitial%icseed_lw         (IM))
-      allocate (Interstitial%icseed_sw         (IM))
-      allocate (Interstitial%flxprf_lw         (IM, Model%levs+1))
-      allocate (Interstitial%flxprf_sw         (IM, Model%levs+1))    
-      allocate (Interstitial%sfc_emiss_byband  (Model%rrtmgp_nBandsLW,IM))
-      allocate (Interstitial%sec_diff_byband   (Model%rrtmgp_nBandsLW,IM))
-      allocate (Interstitial%sfc_alb_nir_dir   (Model%rrtmgp_nBandsSW,IM))
-      allocate (Interstitial%sfc_alb_nir_dif   (Model%rrtmgp_nBandsSW,IM))
-      allocate (Interstitial%sfc_alb_uvvis_dir (Model%rrtmgp_nBandsSW,IM))
-      allocate (Interstitial%sfc_alb_uvvis_dif (Model%rrtmgp_nBandsSW,IM))
-      allocate (Interstitial%toa_src_sw        (IM,Model%rrtmgp_nGptsSW))
-      allocate (Interstitial%toa_src_lw        (IM,Model%rrtmgp_nGptsLW))
-      allocate (Interstitial%active_gases_array(Model%nGases))
+       allocate (Interstitial%tracer               (IM, Model%levs,Model%ntrac))
+       allocate (Interstitial%tv_lay               (IM, Model%levs))
+       allocate (Interstitial%relhum               (IM, Model%levs))
+       allocate (Interstitial%qs_lay               (IM, Model%levs))
+       allocate (Interstitial%q_lay                (IM, Model%levs))
+       allocate (Interstitial%deltaZ               (IM, Model%levs))
+       allocate (Interstitial%p_lev                (IM, Model%levs+1))
+       allocate (Interstitial%p_lay                (IM, Model%levs))
+       allocate (Interstitial%t_lev                (IM, Model%levs+1))
+       allocate (Interstitial%t_lay                (IM, Model%levs))
+       allocate (Interstitial%cloud_overlap_param  (IM, Model%levs))
+       allocate (Interstitial%precip_overlap_param (IM, Model%levs))
+       allocate (Interstitial%fluxlwDOWN_allsky    (IM, Model%levs+1))
+       allocate (Interstitial%fluxlwUP_clrsky      (IM, Model%levs+1))
+       allocate (Interstitial%fluxlwDOWN_clrsky    (IM, Model%levs+1))
+       allocate (Interstitial%fluxswUP_allsky      (IM, Model%levs+1))
+       allocate (Interstitial%fluxswDOWN_allsky    (IM, Model%levs+1))
+       allocate (Interstitial%fluxswUP_clrsky      (IM, Model%levs+1))
+       allocate (Interstitial%fluxswDOWN_clrsky    (IM, Model%levs+1))      
+       allocate (Interstitial%aerosolslw           (IM, Model%levs, Model%rrtmgp_nBandsLW, NF_AELW))
+       allocate (Interstitial%aerosolssw           (IM, Model%levs, Model%rrtmgp_nBandsSW, NF_AESW))
+       allocate (Interstitial%cld_frac             (IM, Model%levs))
+       allocate (Interstitial%cld_lwp              (IM, Model%levs))
+       allocate (Interstitial%cld_reliq            (IM, Model%levs))
+       allocate (Interstitial%cld_iwp              (IM, Model%levs))
+       allocate (Interstitial%cld_reice            (IM, Model%levs))
+       allocate (Interstitial%cld_swp              (IM, Model%levs))
+       allocate (Interstitial%cld_resnow           (IM, Model%levs))
+       allocate (Interstitial%cld_rwp              (IM, Model%levs))
+       allocate (Interstitial%cld_rerain           (IM, Model%levs))
+       allocate (Interstitial%precip_frac          (IM, Model%levs))
+       allocate (Interstitial%icseed_lw            (IM))
+       allocate (Interstitial%icseed_sw            (IM))      
+       allocate (Interstitial%flxprf_lw            (IM, Model%levs+1))
+       allocate (Interstitial%flxprf_sw            (IM, Model%levs+1))
+       allocate (Interstitial%sfc_emiss_byband     (Model%rrtmgp_nBandsLW,IM))
+       allocate (Interstitial%sec_diff_byband      (Model%rrtmgp_nBandsLW,IM))
+       allocate (Interstitial%sfc_alb_nir_dir      (Model%rrtmgp_nBandsSW,IM))
+       allocate (Interstitial%sfc_alb_nir_dif      (Model%rrtmgp_nBandsSW,IM))
+       allocate (Interstitial%sfc_alb_uvvis_dir    (Model%rrtmgp_nBandsSW,IM))
+       allocate (Interstitial%sfc_alb_uvvis_dif    (Model%rrtmgp_nBandsSW,IM))
+       allocate (Interstitial%toa_src_sw           (IM,Model%rrtmgp_nGptsSW))
+       allocate (Interstitial%toa_src_lw           (IM,Model%rrtmgp_nGptsLW))
+       allocate (Interstitial%active_gases_array   (Model%nGases))
     end if
 ! CIRES UGWP v0
     allocate (Interstitial%gw_dudt         (IM,Model%levs))
@@ -6749,48 +6767,47 @@ module GFS_typedefs
     end if
 
     if (Model%do_RRTMGP) then
-      Interstitial%tracer            = clear_val
-      Interstitial%tv_lay            = clear_val
-      Interstitial%relhum            = clear_val
-      Interstitial%p_lev             = clear_val
-      Interstitial%p_lay             = clear_val
-      Interstitial%t_lev             = clear_val
-      Interstitial%t_lay             = clear_val
-      Interstitial%fluxlwUP_allsky   = clear_val
-      Interstitial%fluxlwDOWN_allsky = clear_val
-      Interstitial%fluxlwUP_clrsky   = clear_val
-      Interstitial%fluxlwDOWN_clrsky = clear_val
-      Interstitial%fluxswUP_allsky   = clear_val
-      Interstitial%fluxswDOWN_allsky = clear_val
-      Interstitial%fluxswUP_clrsky   = clear_val
-      Interstitial%fluxswDOWN_clrsky = clear_val
-      Interstitial%aerosolslw        = clear_val
-      Interstitial%aerosolssw        = clear_val
-      Interstitial%cld_frac          = clear_val
-      Interstitial%cld_lwp           = clear_val
-      Interstitial%cld_reliq         = clear_val
-      Interstitial%cld_iwp           = clear_val
-      Interstitial%cld_reice         = clear_val
-      Interstitial%cld_swp           = clear_val
-      Interstitial%cld_resnow        = clear_val
-      Interstitial%cld_rwp           = clear_val
-      Interstitial%cld_rerain        = clear_val
-      Interstitial%hsw0              = clear_val
-      Interstitial%hswc              = clear_val
-      Interstitial%hswb              = clear_val
-      Interstitial%hlw0              = clear_val
-      Interstitial%hlwc              = clear_val
-      Interstitial%hlwb              = clear_val
-      Interstitial%icseed_lw         = clear_val
-      Interstitial%icseed_sw         = clear_val
-      Interstitial%sfc_emiss_byband  = clear_val
-      Interstitial%sec_diff_byband   = clear_val
-      Interstitial%sfc_alb_nir_dir   = clear_val
-      Interstitial%sfc_alb_nir_dif   = clear_val
-      Interstitial%sfc_alb_uvvis_dir = clear_val
-      Interstitial%sfc_alb_uvvis_dif = clear_val
-      Interstitial%toa_src_sw        = clear_val
-      Interstitial%toa_src_lw        = clear_val
+      Interstitial%tracer               = clear_val
+      Interstitial%tv_lay               = clear_val
+      Interstitial%relhum               = clear_val
+      Interstitial%qs_lay               = clear_val
+      Interstitial%q_lay                = clear_val
+      Interstitial%deltaZ               = clear_val
+      Interstitial%p_lev                = clear_val
+      Interstitial%p_lay                = clear_val
+      Interstitial%t_lev                = clear_val
+      Interstitial%t_lay                = clear_val
+      Interstitial%cloud_overlap_param  = clear_val
+      Interstitial%precip_overlap_param = clear_val
+      Interstitial%fluxlwDOWN_allsky    = clear_val
+      Interstitial%fluxlwUP_clrsky      = clear_val
+      Interstitial%fluxlwDOWN_clrsky    = clear_val                
+      Interstitial%fluxswUP_allsky      = clear_val
+      Interstitial%fluxswDOWN_allsky    = clear_val
+      Interstitial%fluxswUP_clrsky      = clear_val
+      Interstitial%fluxswDOWN_clrsky    = clear_val
+      Interstitial%aerosolslw           = clear_val
+      Interstitial%aerosolssw           = clear_val
+      Interstitial%cld_frac             = clear_val
+      Interstitial%cld_lwp              = clear_val
+      Interstitial%cld_reliq            = clear_val
+      Interstitial%cld_iwp              = clear_val
+      Interstitial%cld_reice            = clear_val
+      Interstitial%cld_swp              = clear_val
+      Interstitial%cld_resnow           = clear_val
+      Interstitial%cld_rwp              = clear_val
+      Interstitial%cld_rerain           = clear_val
+      Interstitial%precip_frac          = clear_val
+      Interstitial%icseed_lw            = clear_val
+      Interstitial%icseed_sw            = clear_val
+      Interstitial%sfc_emiss_byband     = clear_val
+      Interstitial%sec_diff_byband      = clear_val
+      Interstitial%sfc_alb_nir_dir      = clear_val
+      Interstitial%sfc_alb_nir_dif      = clear_val
+      Interstitial%sfc_alb_uvvis_dir    = clear_val
+      Interstitial%sfc_alb_uvvis_dif    = clear_val
+      Interstitial%toa_src_sw           = clear_val
+      Interstitial%toa_src_lw           = clear_val
     end if
     !
   end subroutine interstitial_rad_reset
@@ -7421,6 +7438,43 @@ module GFS_typedefs
        write (0,*) 'sum(Interstitial%t2mmp        ) = ', sum(Interstitial%t2mmp           )
        write (0,*) 'sum(Interstitial%q2mp         ) = ', sum(Interstitial%q2mp            )
     end if
+    ! RRTMGP
+    if (Model%do_RRTMGP) then
+       write (0,*) 'sum(Interstitial%aerosolslw           ) = ', sum(Interstitial%aerosolslw  )
+       write (0,*) 'sum(Interstitial%aerosolssw           ) = ', sum(Interstitial%aerosolssw  )
+       write (0,*) 'sum(Interstitial%cld_frac             ) = ', sum(Interstitial%cld_frac    )
+       write (0,*) 'sum(Interstitial%cld_lwp              ) = ', sum(Interstitial%cld_lwp     )
+       write (0,*) 'sum(Interstitial%cld_reliq            ) = ', sum(Interstitial%cld_reliq   )
+       write (0,*) 'sum(Interstitial%cld_iwp              ) = ', sum(Interstitial%cld_iwp     )
+       write (0,*) 'sum(Interstitial%cld_reice            ) = ', sum(Interstitial%cld_reice   )
+       write (0,*) 'sum(Interstitial%cld_swp              ) = ', sum(Interstitial%cld_swp     )
+       write (0,*) 'sum(Interstitial%cld_resnow           ) = ', sum(Interstitial%cld_resnow  )
+       write (0,*) 'sum(Interstitial%cld_rwp              ) = ', sum(Interstitial%cld_rwp     )
+       write (0,*) 'sum(Interstitial%cld_rerain           ) = ', sum(Interstitial%cld_rerain  )
+       write (0,*) 'sum(Interstitial%precip_frac          ) = ', sum(Interstitial%precip_frac )
+       write (0,*) 'sum(Interstitial%icseed_lw            ) = ', sum(Interstitial%icseed_lw   )
+       write (0,*) 'sum(Interstitial%icseed_sw            ) = ', sum(Interstitial%icseed_sw   )
+       write (0,*) 'sum(Interstitial%fluxlwUP_allsky      ) = ', sum(Interstitial%fluxlwUP_allsky  )
+       write (0,*) 'sum(Interstitial%fluxlwDOWN_allsky    ) = ', sum(Interstitial%fluxlwDOWN_allsky)
+       write (0,*) 'sum(Interstitial%fluxlwUP_clrsky      ) = ', sum(Interstitial%fluxlwUP_clrsky  )
+       write (0,*) 'sum(Interstitial%fluxlwDOWN_clrsky    ) = ', sum(Interstitial%fluxlwDOWN_clrsky)
+       write (0,*) 'sum(Interstitial%fluxswUP_allsky      ) = ', sum(Interstitial%fluxswUP_allsky  )
+       write (0,*) 'sum(Interstitial%fluxswDOWN_allsky    ) = ', sum(Interstitial%fluxswDOWN_allsky)
+       write (0,*) 'sum(Interstitial%fluxswUP_clrsky      ) = ', sum(Interstitial%fluxswUP_clrsky  )
+       write (0,*) 'sum(Interstitial%fluxswDOWN_clrsky    ) = ', sum(Interstitial%fluxswDOWN_clrsky)
+       write (0,*) 'sum(Interstitial%relhum               ) = ', sum(Interstitial%relhum      )
+       write (0,*) 'sum(Interstitial%q_lay                ) = ', sum(Interstitial%q_lay       )
+       write (0,*) 'sum(Interstitial%qs_lay               ) = ', sum(Interstitial%qs_lay      )
+       write (0,*) 'sum(Interstitial%deltaZ               ) = ', sum(Interstitial%deltaZ      )
+       write (0,*) 'sum(Interstitial%p_lay                ) = ', sum(Interstitial%p_lay       )
+       write (0,*) 'sum(Interstitial%p_lev                ) = ', sum(Interstitial%p_lev       )
+       write (0,*) 'sum(Interstitial%t_lay                ) = ', sum(Interstitial%t_lay       )
+       write (0,*) 'sum(Interstitial%t_lev                ) = ', sum(Interstitial%t_lev       )
+       write (0,*) 'sum(Interstitial%tv_lay               ) = ', sum(Interstitial%tv_lay      )
+       write (0,*) 'sum(Interstitial%cloud_overlap_param  ) = ', sum(Interstitial%cloud_overlap_param)
+       write (0,*) 'sum(Interstitial%precip_overlap_param ) = ', sum(Interstitial%precip_overlap_param)
+    end if
+
     write (0,*) 'Interstitial_print: end'
     !
   end subroutine interstitial_print

--- a/gfsphysics/GFS_layer/GFS_typedefs.meta
+++ b/gfsphysics/GFS_layer/GFS_typedefs.meta
@@ -2416,12 +2416,30 @@
   units = count
   dimensions =  ()
   type = integer
-[rrtmgp_cld_optics]
-  standard_name = rrtmgp_cloud_optics_flag
-  long_name = Flag to control which RRTMGP cloud-optics scheme (Model%rrtmgp_cld_optics)
+[doG_cldoptics]
+  standard_name = flag_to_calc_lw_cld_optics_using_RRTMG
+  long_name = logical flag to control cloud optics scheme.
   units = flag
-  dimensions =  ()
-  type = integer
+  dimensions = ()
+  type = logical  
+[doGP_cldoptics_PADE]
+  standard_name = flag_to_calc_lw_cld_optics_using_RRTMGP_PADE
+  long_name = logical flag to control cloud optics scheme.
+  units = flag
+  dimensions = ()
+  type = logical
+[doGP_cldoptics_LUT]
+  standard_name = flag_to_calc_lw_cld_optics_using_RRTMGP_LUT
+  long_name = logical flag to control cloud optics scheme.
+  units = flag
+  dimensions = ()
+  type = logical
+[use_LW_jacobian]
+  standard_name = flag_to_calc_RRTMGP_LW_jacobian
+  long_name = logical flag to control RRTMGP LW calculation
+  units = flag
+  dimensions = ()
+  type = logical 
 [rrtmgp_nrghice]
   standard_name = number_of_rrtmgp_ice_roughness
   long_name = number of ice-roughness categories in RRTMGP calculation (Model%rrtmgp_nrghice)
@@ -4301,6 +4319,18 @@
 [ldiag_ugwp]
   standard_name = diag_ugwp_flag
   long_name = flag for CIRES UGWP Diagnostics
+  units = flag
+  dimensions = ()
+  type = logical
+[uni_cld]
+  standard_name = flag_for_uni_cld
+  long_name = flag for uni_cld
+  units = flag
+  dimensions = ()
+  type = logical  
+[lmfshal]
+  standard_name = flag_for_lmfshal
+  long_name = flag for lmfshal
   units = flag
   dimensions = ()
   type = logical
@@ -8810,7 +8840,13 @@
   dimensions = (horizontal_dimension,vertical_dimension)
   type = real
   kind = kind_phys
-  optional = F
+[deltaZ]
+  standard_name = layer_thickness
+  long_name = layer_thickness
+  units = m
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
 [tracer]
   standard_name = chemical_tracers
   long_name = chemical tracers
@@ -8818,132 +8854,32 @@
   dimensions = (horizontal_dimension,vertical_dimension,number_of_tracers)
   type = real
   kind = kind_phys
-  optional = F
-[hsw0]
-  standard_name = RRTMGP_sw_heating_rate_clear_sky
-  long_name = RRTMGP shortwave clear sky heating rate
-  units = K s-1
+[cloud_overlap_param]
+  standard_name = cloud_overlap_param
+  long_name = cloud overlap parameter
+  units = km
   dimensions = (horizontal_dimension,vertical_dimension)
   type = real
   kind = kind_phys
-  optional = T
-[hswc]
-  standard_name = RRTMGP_sw_heating_rate_all_sky
-  long_name = RRTMGP shortwave all sky heating rate
-  units = K s-1
+[precip_overlap_param]
+  standard_name = precip_overlap_param
+  long_name = precipitation overlap parameter
+  units = km
   dimensions = (horizontal_dimension,vertical_dimension)
   type = real
   kind = kind_phys
-  optional = F
-[hswb]
-  standard_name = RRTMGP_sw_heating_rate_spectral
-  long_name = RRTMGP shortwave total sky heating rate (spectral)
-  units = K s-1
-  dimensions = (horizontal_dimension,vertical_dimension,number_of_sw_spectral_points_rrtmgp)
-  type = real
-  kind = kind_phys
-  optional = T
-[hlw0]
-  standard_name = RRTMGP_lw_heating_rate_clear_sky
-  long_name = RRTMGP longwave clear sky heating rate
-  units = K s-1
-  dimensions = (horizontal_dimension,vertical_dimension)
-  type = real
-  kind = kind_phys
-  optional = T
-[hlwc]
-  standard_name = RRTMGP_lw_heating_rate_all_sky
-  long_name = RRTMGP longwave all sky heating rate
-  units = K s-1
-  dimensions = (horizontal_dimension,vertical_dimension)
-  type = real
-  kind = kind_phys
-  optional = F
-[hlwb]
-  standard_name = RRTMGP_lw_heating_rate_spectral
-  long_name = RRTMGP longwave total sky heating rate (spectral)
-  units = K s-1
-  dimensions = (horizontal_dimension,vertical_dimension,number_of_lw_spectral_points_rrtmgp)
-  type = real
-  kind = kind_phys
-  optional = T
 [ipsdsw0]
   standard_name = initial_permutation_seed_sw
   long_name = initial seed for McICA SW 
   units = none
   dimensions = ()
   type = integer
-  optional = F
 [ipsdlw0]
   standard_name = initial_permutation_seed_lw
   long_name = initial seed for McICA LW 
   units = none
   dimensions = ()
   type = integer
-  optional = F
-[cld_frac]
-  standard_name = RRTMGP_total_cloud_fraction
-  long_name = layer total cloud fraction
-  units = frac
-  dimensions = (horizontal_dimension,vertical_dimension)
-  type = real
-  kind = kind_phys
-[cld_lwp]
-  standard_name = RRTMGP_cloud_liquid_water_path
-  long_name = layer cloud liquid water path
-  units = g m-2
-  dimensions = (horizontal_dimension,vertical_dimension)
-  type = real
-  kind = kind_phys
-[cld_reliq]
-  standard_name = RRTMGP_mean_effective_radius_for_liquid_cloud
-  long_name = mean effective radius for liquid cloud
-  units = micron
-  dimensions = (horizontal_dimension,vertical_dimension)
-  type = real
-  kind = kind_phys
-[cld_iwp]
-  standard_name = RRTMGP_cloud_ice_water_path
-  long_name = layer cloud ice water path
-  units = g m-2
-  dimensions = (horizontal_dimension,vertical_dimension)
-  type = real
-  kind = kind_phys
-[cld_reice]
-  standard_name = RRTMGP_mean_effective_radius_for_ice_cloud
-  long_name = mean effective radius for ice cloud
-  units = micron
-  dimensions = (horizontal_dimension,vertical_dimension)
-  type = real
-  kind = kind_phys
-[cld_rwp]
-  standard_name = RRTMGP_cloud_rain_water_path
-  long_name = cloud rain water path
-  units = g m-2
-  dimensions = (horizontal_dimension,vertical_dimension)
-  type = real
-  kind = kind_phys
-[cld_rerain]
-  standard_name = RRTMGP_mean_effective_radius_for_rain_drop
-  long_name = mean effective radius for rain drop
-  units = micron
-  dimensions = (horizontal_dimension,vertical_dimension)
-  type = real
-  kind = kind_phys
-[cld_swp]
-  standard_name = RRTMGP_cloud_snow_water_path
-  long_name = cloud snow water path
-  units = g m-2
-  dimensions = (horizontal_dimension,vertical_dimension)
-  type = real
-  kind = kind_phys
-[cld_resnow]
-  standard_name = RRTMGP_mean_effective_radius_for_snow_flake
-  long_name = mean effective radius for snow flake
-  units = micron
-  dimensions = (horizontal_dimension,vertical_dimension)
-  type = real
-  kind = kind_phys
 [cldtausw]
   standard_name = RRTMGP_cloud_optical_depth_layers_at_0_55mu_band
   long_name = approx .55mu band layer cloud optical depth
@@ -8990,7 +8926,27 @@
   dimensions = (horizontal_dimension,vertical_dimension_plus_one)
   type = real
   kind = kind_phys
-  optional = F
+[sktp1r]
+  standard_name = surface_skin_temperature_at_previous_time_step
+  long_name = surface skin temperature at previous time step
+  units = K
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+[fluxlwUP_jac]
+  standard_name = RRTMGP_jacobian_of_lw_flux_profile_upward
+  long_name = RRTMGP Jacobian upward longwave flux profile
+  units = W m-2 K-1
+  dimensions = (horizontal_dimension,vertical_dimension_plus_one)
+  type = real
+  kind = kind_phys
+[fluxlwDOWN_jac]
+  standard_name = RRTMGP_jacobian_of_lw_flux_profile_downward
+  long_name = RRTMGP Jacobian downward of longwave flux profile
+  units = W m-2 K-1
+  dimensions = (horizontal_dimension,vertical_dimension_plus_one)
+  type = real
+  kind = kind_phys
 [fluxswUP_allsky]
   standard_name = RRTMGP_sw_flux_profile_upward_allsky
   long_name = RRTMGP upward shortwave all-sky flux profile
@@ -9100,99 +9056,117 @@
   units = none
   dimensions = (horizontal_dimension)
   type = integer
-  optional = F
 [icseed_sw]
   standard_name = seed_random_numbers_sw_for_RRTMGP
   long_name = seed for random number generation for shortwave radiation
   units = none
   dimensions = (horizontal_dimension)
   type = integer
-  optional = F
+[precip_frac]
+  standard_name = precipitation_fraction_by_layer
+  long_name = precipitation fraction in each layer
+  units = frac
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
 [sw_gas_props]
   standard_name = coefficients_for_sw_gas_optics
   long_name = DDT containing spectral information for RRTMGP SW radiation scheme
   units = DDT
   dimensions = ()
   type = ty_gas_optics_rrtmgp
-  optional = F
 [sw_cloud_props]
   standard_name = coefficients_for_sw_cloud_optics
   long_name = DDT containing spectral information for RRTMGP SW radiation scheme
   units = DDT
   dimensions = ()
   type = ty_cloud_optics
-  optional = F
 [sw_optical_props_clrsky]
   standard_name = shortwave_optical_properties_for_clear_sky
   long_name = Fortran DDT containing RRTMGP optical properties
   units = DDT
   dimensions = ()
   type = ty_optical_props_2str
-  optional = F
 [sw_optical_props_cloudsByBand]
   standard_name = shortwave_optical_properties_for_cloudy_atmosphere_by_band
   long_name = Fortran DDT containing RRTMGP optical properties
   units = DDT
   dimensions = ()
   type = ty_optical_props_2str
+[sw_optical_props_precipByBand]
+  standard_name = shortwave_optical_properties_for_precipitation_by_band
+  long_name = Fortran DDT containing RRTMGP optical properties
+  units = DDT
+  dimensions = ()
+  type = ty_optical_props_2str  
+[sw_optical_props_precip]
+  standard_name = shortwave_optical_properties_for_precipitation
+  long_name = Fortran DDT containing RRTMGP optical properties
+  units = DDT
+  dimensions = ()
+  type = ty_optical_props_2str  
 [sw_optical_props_clouds]
   standard_name = shortwave_optical_properties_for_cloudy_atmosphere
   long_name = Fortran DDT containing RRTMGP optical properties
   units = DDT
   dimensions = ()
   type = ty_optical_props_2str
-  optional = F
 [sw_optical_props_aerosol]
   standard_name = shortwave_optical_properties_for_aerosols
   long_name = Fortran DDT containing RRTMGP optical properties
   units = DDT
   dimensions = ()
   type = ty_optical_props_2str
-  optional = F
 [gas_concentrations]
   standard_name = Gas_concentrations_for_RRTMGP_suite
   long_name = DDT containing gas concentrations for RRTMGP radiation scheme
   units = DDT
   dimensions = ()
   type = ty_gas_concs
-  optional = F
 [sources]
   standard_name = longwave_source_function
   long_name = Fortran DDT containing RRTMGP source functions
   units = DDT
   dimensions = ()
   type = ty_source_func_lw
-  optional = F
 [lw_gas_props]
   standard_name = coefficients_for_lw_gas_optics
   long_name = DDT containing spectral information for RRTMGP LW radiation scheme
   units = DDT
   dimensions = ()
   type = ty_gas_optics_rrtmgp
-  optional = F
 [lw_cloud_props]
   standard_name = coefficients_for_lw_cloud_optics
   long_name = DDT containing spectral information for RRTMGP LW radiation scheme
   units = DDT
   dimensions = ()
   type = ty_cloud_optics
-  optional = F
 [lw_optical_props_clrsky]
   standard_name = longwave_optical_properties_for_clear_sky
   long_name = Fortran DDT containing RRTMGP optical properties
   units = DDT
   dimensions = ()
   type = ty_optical_props_1scl
-  optional = F
 [lw_optical_props_clouds]
   standard_name = longwave_optical_properties_for_cloudy_atmosphere
   long_name = Fortran DDT containing RRTMGP optical properties
   units = DDT
   dimensions = ()
   type = ty_optical_props_1scl
-  optional = F
+[lw_optical_props_precip]
+  standard_name = longwave_optical_properties_for_precipitation
+  long_name = Fortran DDT containing RRTMGP optical properties
+  units = DDT
+  dimensions = ()
+  type = ty_optical_props_1scl
 [lw_optical_props_cloudsByBand]
   standard_name = longwave_optical_properties_for_cloudy_atmosphere_by_band
+  long_name = Fortran DDT containing RRTMGP optical properties
+  units = DDT
+  dimensions = ()
+  type = ty_optical_props_1scl
+[lw_optical_props_precipByBand]
+  standard_name = longwave_optical_properties_for_precipitation_by_band
   long_name = Fortran DDT containing RRTMGP optical properties
   units = DDT
   dimensions = ()
@@ -9203,7 +9177,6 @@
   units = DDT
   dimensions = ()
   type = ty_optical_props_1scl
-  optional = F
 [sfc_emiss_byband]
   standard_name = surface_emissivity_in_each_RRTMGP_LW_band
   long_name = surface emissivity in each RRTMGP LW band
@@ -9451,6 +9424,13 @@
   dimensions = ()
   type = real
   kind = kind_phys
+[con_epsqs]
+  standard_name = minimum_value_of_saturation_mixing_ratio
+  long_name = floor value for saturation mixing ratio
+  units = kg kg-1
+  dimensions = ()
+  type = real
+  kind = kind_phys  
 [con_epsm1]
   standard_name = ratio_of_dry_air_to_water_vapor_gas_constants_minus_one
   long_name = (rd/rv) - 1


### PR DESCRIPTION
This PR adds the new tracer_sanitizer scheme to the CCPP prebuild config and two suite definition files (commented out in one of them).

The PR also updates fv3atm with the latest changes from EMC's develop branch (RRTMGP update).

Associated PRs:
https://github.com/NOAA-GSD/ccpp-physics/pull/49
https://github.com/NOAA-GSD/fv3atm/pull/44
https://github.com/NOAA-GSD/ufs-weather-model/pull/36

For regression testing, see https://github.com/NOAA-GSD/ufs-weather-model/pull/36.