### PR TITLE
Update submodule pointer for ccpp-physics (changes for flexible number of soil levels)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,7 @@
 	branch = gsd/develop
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/NOAA-GSD/ccpp-physics
-	branch = gsd/develop
+	#url = https://github.com/NOAA-GSD/ccpp-physics
+	#branch = gsd/develop
+	url = https://github.com/tanyasmirnova/ccpp-physics
+	branch = gcycle_ruc

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,5 @@
 	branch = gsd/develop
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	#url = https://github.com/NOAA-GSD/ccpp-physics
-	#branch = gsd/develop
-	url = https://github.com/tanyasmirnova/ccpp-physics
-	branch = gcycle_ruc
+	url = https://github.com/NOAA-GSD/ccpp-physics
+	branch = gsd/develop

--- a/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -3787,11 +3787,6 @@ module GFS_typedefs
     Model%lsm              = lsm
     Model%lsoil            = lsoil
 #ifdef CCPP
-    ! Consistency check for RUC LSM
-    if (Model%lsm == Model%lsm_ruc .and. Model%nscyc>0) then
-      write(0,*) 'Logic error: RUC LSM cannot be used with surface data cycling at this point (fhcyc>0)'
-      stop
-    end if
     ! Flag to read leaf area index from input files (initial conditions)
     Model%rdlai = rdlai
     if (Model%rdlai .and. .not. Model%lsm == Model%lsm_ruc) then


### PR DESCRIPTION
## Description

This PR
- updates the submodule pointer for ccpp-physics for @tanyasmirnova's gcycle update
- removes a guard in `GFS_typedefs.F90` that prevents using RUC LSM with `fhcyc>0`

Associated PRs:
https://github.com/NOAA-GSD/ccpp-physics/pull/47
https://github.com/NOAA-GSD/fv3atm/pull/47
https://github.com/NOAA-GSD/ufs-weather-model/pull/39

For regression testing information, see https://github.com/NOAA-GSD/ufs-weather-model/pull/39.
