### PR TITLE
Sea ice in RUC LSM 

### DIFF
--- a/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -242,6 +242,8 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: tisfc  (:)   => null()  !< surface temperature over ice fraction
     real (kind=kind_phys), pointer :: tiice(:,:)   => null()  !< internal ice temperature
     real (kind=kind_phys), pointer :: snowd  (:)   => null()  !< snow depth water equivalent in mm ; same as snwdph
+    real (kind=kind_phys), pointer :: snowd_land (:)   => null()  !< snow depth water equivalent in mm ; same as snwdph
+    real (kind=kind_phys), pointer :: snowd_ice  (:)   => null()  !< snow depth water equivalent in mm ; same as snwdph
     real (kind=kind_phys), pointer :: zorl   (:)   => null()  !< composite surface roughness in cm
     real (kind=kind_phys), pointer :: zorlo  (:)   => null()  !< ocean surface roughness in cm
     real (kind=kind_phys), pointer :: zorll  (:)   => null()  !< land surface roughness in cm
@@ -253,6 +255,7 @@ module GFS_typedefs
 
 !--- In (radiation only)
     real (kind=kind_phys), pointer :: sncovr (:)   => null()  !< snow cover in fraction
+    real (kind=kind_phys), pointer :: sncovr_ice (:)   => null()  !< snow cover in fraction
     real (kind=kind_phys), pointer :: snoalb (:)   => null()  !< maximum snow albedo in fraction
     real (kind=kind_phys), pointer :: alvsf  (:)   => null()  !< mean vis albedo with strong cosz dependency
     real (kind=kind_phys), pointer :: alnsf  (:)   => null()  !< mean nir albedo with strong cosz dependency
@@ -369,12 +372,22 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: flag_frsoil(:,:) => null()  !< RUC LSM: flag for frozen soil physics
     !
     real (kind=kind_phys), pointer :: clw_surf(:)      => null()  !< RUC LSM: moist cloud water mixing ratio at surface
+    real (kind=kind_phys), pointer :: clw_surf_land(:) => null()  !< RUC LSM: moist cloud water mixing ratio at surface over land
+    real (kind=kind_phys), pointer :: clw_surf_ice(:)  => null()  !< RUC LSM: moist cloud water mixing ratio at surface over ice
     real (kind=kind_phys), pointer :: qwv_surf(:)      => null()  !< RUC LSM: water vapor mixing ratio at surface
+    real (kind=kind_phys), pointer :: qwv_surf_land(:) => null()  !< RUC LSM: water vapor mixing ratio at surface
+    real (kind=kind_phys), pointer :: qwv_surf_ice(:)  => null()  !< RUC LSM: water vapor mixing ratio at surface
     real (kind=kind_phys), pointer :: cndm_surf(:)     => null()  !< RUC LSM: surface condensation mass
+    real (kind=kind_phys), pointer :: cndm_surf_land(:)=> null()  !< RUC LSM: surface condensation mass over land
+    real (kind=kind_phys), pointer :: cndm_surf_ice(:) => null()  !< RUC LSM: surface condensation mass over ice
     real (kind=kind_phys), pointer :: rhofr(:)         => null()  !< RUC LSM: density of frozen precipitation
-    real (kind=kind_phys), pointer :: tsnow(:)         => null()  !< RUC LSM: snow temperature at the bottom of the first soil layer
-    real (kind=kind_phys), pointer :: snowfallac(:)    => null()  !< ruc lsm diagnostics
+    real (kind=kind_phys), pointer :: tsnow(:)         => null()  !< RUC LSM: snow temperature at the bottom of the first snow layer
+    real (kind=kind_phys), pointer :: tsnow_land(:)    => null()  !< RUC LSM: snow temperature at the bottom of the first snow layer over land
+    real (kind=kind_phys), pointer :: tsnow_ice(:)     => null()  !< RUC LSM: snow temperature at the bottom of the first snow layer over ice
     real (kind=kind_phys), pointer :: acsnow(:)        => null()  !< ruc lsm diagnostics
+    real (kind=kind_phys), pointer :: snowfallac(:)    => null()  !< ruc lsm diagnostics
+    real (kind=kind_phys), pointer :: snowfallac_land(:) => null()  !< ruc lsm diagnostics over land
+    real (kind=kind_phys), pointer :: snowfallac_ice(:)  => null()  !< ruc lsm diagnostics over ice
 
     !  MYNN surface layer
     real (kind=kind_phys), pointer :: ustm (:)         => null()  !u* including drag
@@ -775,13 +788,15 @@ module GFS_typedefs
     integer              :: lsm_noahmp=2    !< flag for NOAH land surface model
     integer              :: lsm_ruc=3       !< flag for RUC land surface model
     integer              :: lsoil           !< number of soil layers
-    integer              :: kice=2          !< number of layers in sice
 #ifdef CCPP
     integer              :: lsoil_lsm       !< number of soil layers internal to land surface model
     integer              :: lsnow_lsm       !< maximum number of snow layers internal to land surface model
     integer              :: lsnow_lsm_lbound!< lower bound for snow arrays, depending on lsnow_lsm
     real(kind=kind_phys), pointer :: zs(:) => null() !< depth of soil levels for land surface model
     logical              :: rdlai
+    integer              :: kice            !< number of layers in ice model
+#else
+    integer              :: kice=2          !< number of layers in sice
 #endif
     integer              :: ivegsrc         !< ivegsrc = 0   => USGS, 
                                             !< ivegsrc = 1   => IGBP (20 category)
@@ -1359,7 +1374,9 @@ module GFS_typedefs
 !--- Out (radiation only)
     real (kind=kind_phys), pointer :: htrsw (:,:)  => null()  !< swh  total sky sw heating rate in k/sec
     real (kind=kind_phys), pointer :: htrlw (:,:)  => null()  !< hlw  total sky lw heating rate in k/sec
-    real (kind=kind_phys), pointer :: sfalb (:)    => null()  !< mean surface diffused sw albedo 
+    real (kind=kind_phys), pointer :: sfalb (:)    => null()  !< mean surface diffused sw albedo
+    real (kind=kind_phys), pointer :: sfalb_land (:) => null()  !< mean surface diffused sw albedo
+    real (kind=kind_phys), pointer :: sfalb_ice  (:) => null()  !< mean surface diffused sw albedo
 
     real (kind=kind_phys), pointer :: coszen(:)    => null()  !< mean cos of zenith angle over rad call period
     real (kind=kind_phys), pointer :: tsflw (:)    => null()  !< surface air temp during lw calculation in k 
@@ -1705,11 +1722,18 @@ module GFS_typedefs
     real (kind=kind_phys), pointer      :: clouds(:,:,:)      => null()  !<
     real (kind=kind_phys), pointer      :: clw(:,:,:)         => null()  !<
     real (kind=kind_phys), pointer      :: clw_surf(:)        => null()  !<
+    real (kind=kind_phys), pointer      :: clw_surf_land(:) => null()  !<
+    real (kind=kind_phys), pointer      :: clw_surf_ice(:)  => null()  !<
+    real (kind=kind_phys), pointer      :: qwv_surf(:)        => null()  !<
+    real (kind=kind_phys), pointer      :: qwv_surf_land(:)   => null()  !<
+    real (kind=kind_phys), pointer      :: qwv_surf_ice(:)    => null()  !<
     real (kind=kind_phys), pointer      :: clx(:,:)           => null()  !<
     real (kind=kind_phys), pointer      :: cmm_ice(:)         => null()  !<
     real (kind=kind_phys), pointer      :: cmm_land(:)        => null()  !<
     real (kind=kind_phys), pointer      :: cmm_ocean(:)       => null()  !<
     real (kind=kind_phys), pointer      :: cndm_surf(:)       => null()  !<
+    real (kind=kind_phys), pointer      :: cndm_surf_land(:) => null()  !<
+    real (kind=kind_phys), pointer      :: cndm_surf_ice(:)  => null()  !<
     real (kind=kind_phys), pointer      :: cnv_dqldt(:,:)     => null()  !<
     real (kind=kind_phys), pointer      :: cnv_fice(:,:)      => null()  !<
     real (kind=kind_phys), pointer      :: cnv_mfd(:,:)       => null()  !<
@@ -1939,6 +1963,11 @@ module GFS_typedefs
     real (kind=kind_phys), pointer      :: tsfc_ocean(:)      => null()  !<
     real (kind=kind_phys), pointer      :: tsfg(:)            => null()  !<
     real (kind=kind_phys), pointer      :: tsnow(:)           => null()  !<
+    real (kind=kind_phys), pointer      :: tsnow_land(:)      => null()  !<
+    real (kind=kind_phys), pointer      :: tsnow_ice(:)       => null()  !<
+    real (kind=kind_phys), pointer      :: snowfallac(:)      => null()  !<
+    real (kind=kind_phys), pointer      :: snowfallac_land(:) => null()  !<
+    real (kind=kind_phys), pointer      :: snowfallac_ice(:)  => null()  !<
     real (kind=kind_phys), pointer      :: tsurf(:)           => null()  !<
     real (kind=kind_phys), pointer      :: tsurf_ice(:)       => null()  !<
     real (kind=kind_phys), pointer      :: tsurf_land(:)      => null()  !<
@@ -2231,6 +2260,8 @@ module GFS_typedefs
     allocate (Sfcprop%tisfc    (IM))
     allocate (Sfcprop%tiice    (IM,Model%kice))
     allocate (Sfcprop%snowd    (IM))
+    allocate (Sfcprop%snowd_land  (IM))
+    allocate (Sfcprop%snowd_ice   (IM))
     allocate (Sfcprop%zorl     (IM))
     allocate (Sfcprop%zorlo    (IM))
     allocate (Sfcprop%zorll    (IM))
@@ -2251,6 +2282,8 @@ module GFS_typedefs
     Sfcprop%tisfc     = clear_val
     Sfcprop%tiice     = clear_val
     Sfcprop%snowd     = clear_val
+    Sfcprop%snowd_land   = clear_val
+    Sfcprop%snowd_ice    = clear_val
     Sfcprop%zorl      = clear_val
     Sfcprop%zorlo     = clear_val
     Sfcprop%zorll     = clear_val
@@ -2262,6 +2295,7 @@ module GFS_typedefs
 
 !--- In (radiation only)
     allocate (Sfcprop%sncovr (IM))
+    allocate (Sfcprop%sncovr_ice (IM))
     allocate (Sfcprop%snoalb (IM))
     allocate (Sfcprop%alvsf  (IM))
     allocate (Sfcprop%alnsf  (IM))
@@ -2271,6 +2305,7 @@ module GFS_typedefs
     allocate (Sfcprop%facwf  (IM))
 
     Sfcprop%sncovr = clear_val
+    Sfcprop%sncovr_ice  = clear_val
     Sfcprop%snoalb = clear_val
     Sfcprop%alvsf  = clear_val
     Sfcprop%alnsf  = clear_val
@@ -2315,6 +2350,7 @@ module GFS_typedefs
     allocate (Sfcprop%hice   (IM))
     allocate (Sfcprop%weasd  (IM))
     allocate (Sfcprop%sncovr (IM))
+    allocate (Sfcprop%sncovr_ice  (IM))
     allocate (Sfcprop%canopy (IM))
     allocate (Sfcprop%ffmm   (IM))
     allocate (Sfcprop%ffhh   (IM))
@@ -2328,6 +2364,7 @@ module GFS_typedefs
     Sfcprop%hice   = clear_val
     Sfcprop%weasd  = clear_val
     Sfcprop%sncovr = clear_val
+    Sfcprop%sncovr_ice  = clear_val
     Sfcprop%canopy = clear_val
     Sfcprop%ffmm   = clear_val
     Sfcprop%ffhh   = clear_val
@@ -2508,26 +2545,47 @@ module GFS_typedefs
        allocate (Sfcprop%smois       (IM,Model%lsoil_lsm))
        allocate (Sfcprop%tslb        (IM,Model%lsoil_lsm))
        allocate (Sfcprop%flag_frsoil (IM,Model%lsoil_lsm))
-       allocate (Sfcprop%clw_surf    (IM))
-       allocate (Sfcprop%qwv_surf    (IM))
-       allocate (Sfcprop%cndm_surf   (IM))
-       allocate (Sfcprop%rhofr       (IM))
-       allocate (Sfcprop%tsnow       (IM))
-       allocate (Sfcprop%snowfallac  (IM))
-       allocate (Sfcprop%acsnow      (IM))
+       allocate (Sfcprop%clw_surf      (IM))
+       allocate (Sfcprop%clw_surf_land (IM))
+       allocate (Sfcprop%clw_surf_ice  (IM))
+       allocate (Sfcprop%qwv_surf      (IM))
+       allocate (Sfcprop%qwv_surf_land (IM))
+       allocate (Sfcprop%qwv_surf_ice  (IM))
+       allocate (Sfcprop%cndm_surf     (IM))
+       allocate (Sfcprop%cndm_surf_land(IM))
+       allocate (Sfcprop%cndm_surf_ice (IM))
+       allocate (Sfcprop%rhofr         (IM))
+       allocate (Sfcprop%tsnow         (IM))
+       allocate (Sfcprop%tsnow_land    (IM))
+       allocate (Sfcprop%tsnow_ice     (IM))
+       allocate (Sfcprop%snowfallac    (IM))
+       allocate (Sfcprop%snowfallac_land (IM))
+       allocate (Sfcprop%snowfallac_ice  (IM))
+       allocate (Sfcprop%acsnow        (IM))
+
        !
        Sfcprop%wetness     = clear_val
        Sfcprop%sh2o        = clear_val
        Sfcprop%keepsmfr    = clear_val
        Sfcprop%smois       = clear_val
        Sfcprop%tslb        = clear_val
-       Sfcprop%clw_surf    = clear_val
-       Sfcprop%qwv_surf    = clear_val
-       Sfcprop%cndm_surf   = clear_val
+       Sfcprop%clw_surf      = clear_val
+       Sfcprop%clw_surf_land = clear_val
+       Sfcprop%clw_surf_ice  = clear_val
+       Sfcprop%qwv_surf      = clear_val
+       Sfcprop%qwv_surf_land = clear_val
+       Sfcprop%qwv_surf_ice  = clear_val
+       Sfcprop%cndm_surf      = clear_val
+       Sfcprop%cndm_surf_land = clear_val
+       Sfcprop%cndm_surf_ice  = clear_val
        Sfcprop%flag_frsoil = clear_val
        Sfcprop%rhofr       = clear_val
        Sfcprop%tsnow       = clear_val
+       Sfcprop%tsnow_land  = clear_val
+       Sfcprop%tsnow_ice   = clear_val
        Sfcprop%snowfallac  = clear_val
+       Sfcprop%snowfallac_land = clear_val
+       Sfcprop%snowfallac_ice  = clear_val
        Sfcprop%acsnow      = clear_val
        !
        if (Model%rdlai) then
@@ -3053,6 +3111,7 @@ module GFS_typedefs
     integer              :: lsoil_lsm      =  -1             !< number of soil layers internal to land surface model; -1 use lsoil
     integer              :: lsnow_lsm      =  3              !< maximum number of snow layers internal to land surface model
     logical              :: rdlai          = .false.
+    integer              :: kice           =  -1             !< number of layers in ice; -1 use 2
 #endif
     integer              :: ivegsrc        =  2              !< ivegsrc = 0   => USGS,
                                                              !< ivegsrc = 1   => IGBP (20 category)
@@ -3361,7 +3420,7 @@ module GFS_typedefs
                                avg_max_length,                                              &
                           !--- land/surface model control
 #ifdef CCPP
-                               lsm, lsoil, lsoil_lsm, lsnow_lsm, rdlai,                     &
+                               lsm, lsoil, lsoil_lsm, lsnow_lsm, kice, rdlai,               &
                                nmtvr, ivegsrc, use_ufo,                                     &
 #else
                                lsm, lsoil, nmtvr, ivegsrc, use_ufo,                         &
@@ -3807,6 +3866,13 @@ module GFS_typedefs
     if (Model%lsm==Model%lsm_ruc) then
        allocate (Model%zs(Model%lsoil_lsm))
        Model%zs = clear_val
+    endif
+    !
+    ! Set number of ice model layers
+    if (kice==-1) then
+      Model%kice      = 2
+    else
+      Model%kice      = kice
     end if
     !
     if (lsnow_lsm /= 3) then
@@ -4927,6 +4993,7 @@ module GFS_typedefs
       print *, ' rdlai             : ', Model%rdlai
       print *, ' lsoil_lsm         : ', Model%lsoil_lsm
       print *, ' lsnow_lsm         : ', Model%lsnow_lsm
+      print *, ' kice              : ', Model%kice
 #endif
       print *, ' ivegsrc           : ', Model%ivegsrc
       print *, ' isot              : ', Model%isot
@@ -5465,6 +5532,8 @@ module GFS_typedefs
     allocate (Radtend%htrsw  (IM,Model%levs))
     allocate (Radtend%htrlw  (IM,Model%levs))
     allocate (Radtend%sfalb  (IM))
+    allocate (Radtend%sfalb_land (IM))
+    allocate (Radtend%sfalb_ice  (IM))
     allocate (Radtend%coszen (IM))
     allocate (Radtend%tsflw  (IM))
     allocate (Radtend%semis  (IM))
@@ -5472,6 +5541,8 @@ module GFS_typedefs
     Radtend%htrsw  = clear_val
     Radtend%htrlw  = clear_val
     Radtend%sfalb  = clear_val
+    Radtend%sfalb_land = clear_val
+    Radtend%sfalb_ice  = clear_val
     Radtend%coszen = clear_val
     Radtend%tsflw  = clear_val
     Radtend%semis  = clear_val

--- a/gfsphysics/GFS_layer/GFS_typedefs.meta
+++ b/gfsphysics/GFS_layer/GFS_typedefs.meta
@@ -592,6 +592,13 @@
   dimensions = (horizontal_dimension)
   type = real
   kind = kind_phys
+[sncovr_ice]
+  standard_name = surface_snow_area_fraction_over_ice
+  long_name = surface snow area fraction over ice
+  units = frac
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
 [snoalb]
   standard_name = upper_bound_on_max_albedo_over_deep_snow
   long_name = maximum snow albedo
@@ -1252,6 +1259,20 @@
   dimensions = (horizontal_dimension)
   type = real
   kind = kind_phys
+[clw_surf_land]
+  standard_name = cloud_condensed_water_mixing_ratio_at_surface_over_land
+  long_name = moist cloud water mixing ratio at surface over land
+  units = kg kg-1
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+[clw_surf_ice]
+  standard_name = cloud_condensed_water_mixing_ratio_at_surface_over_ice
+  long_name = moist cloud water mixing ratio at surface over ice
+  units = kg kg-1
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
   active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme) 
 [qwv_surf]
   standard_name = water_vapor_mixing_ratio_at_surface
@@ -1260,10 +1281,42 @@
   dimensions = (horizontal_dimension)
   type = real
   kind = kind_phys
+  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+[qwv_surf_land]
+  standard_name = water_vapor_mixing_ratio_at_surface_over_land
+  long_name = water vapor mixing ratio at surface over land
+  units = kg kg-1
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+[qwv_surf_ice]
+  standard_name = water_vapor_mixing_ratio_at_surface_over_ice
+  long_name = water vapor mixing ratio at surface over ice
+  units = kg kg-1
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
   active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme) 
 [cndm_surf]
   standard_name = surface_condensation_mass
   long_name = surface condensation mass
+  units = kg m-2
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+[cndm_surf_land]
+  standard_name = surface_condensation_mass_over_land
+  long_name = surface condensation mass
+  units = kg m-2
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+[cndm_surf_ice]
+  standard_name = surface_condensation_mass_over_ice
+  long_name = surface condensation mass over ice
   units = kg m-2
   dimensions = (horizontal_dimension)
   type = real
@@ -1292,10 +1345,42 @@
   dimensions = (horizontal_dimension)
   type = real
   kind = kind_phys
+  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+[tsnow_land]
+  standard_name = snow_temperature_bottom_first_layer_over_land
+  long_name = snow temperature at the bottom of the first snow layer over land
+  units = K
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+[tsnow_ice]
+  standard_name = snow_temperature_bottom_first_layer_over_ice
+  long_name = snow temperature at the bottom of the first snow layer over ice
+  units = K
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
   active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme) 
 [snowfallac]
   standard_name = total_accumulated_snowfall
   long_name = run-total snow accumulation on the ground
+  units = kg m-2
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+[snowfallac_land]
+  standard_name = total_accumulated_snowfall_over_land
+  long_name = run-total snow accumulation on the ground
+  units = kg m-2
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+[snowfallac_ice]
+  standard_name = total_accumulated_snowfall_over_ice
+  long_name = run-total snow accumulation on the ice
   units = kg m-2
   dimensions = (horizontal_dimension)
   type = real
@@ -5111,6 +5196,20 @@
 [sfalb]
   standard_name = surface_diffused_shortwave_albedo
   long_name = mean surface diffused sw albedo
+  units = frac
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+[sfalb_land]
+  standard_name = surface_diffused_shortwave_albedo_over_land
+  long_name = mean surface diffused sw albed over land with snow effect
+  units = frac
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+[sfalb_ice]
+  standard_name = surface_diffused_shortwave_albedo_over_ice
+  long_name = mean surface diffused sw albedo over ice with snow effect
   units = frac
   dimensions = (horizontal_dimension)
   type = real


### PR DESCRIPTION
## Description
Option for sea ice in RUC LSM is reinstated. Now sfc_drv_ruc.F90 has two calls: for land and sea ice.




### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes #<issue_number>
- fixes noaa-emc/fv3atm/issues/<issue_number>



## Testing

How were these changes tested?  
What compilers / HPCs was it tested with?  
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  
Have the ufs-weather-model regression test been run? On what platform?  
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on noaa-emc/nems/pull/<pr_number>
- waiting on noaa-emc/fv3atm/pull/<pr_number>
