### PR TITLE
Stochastic land perturbations: add roughness length over land to the perturbed variables

### DIFF
--- a/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -6235,12 +6235,12 @@ module GFS_typedefs
       Diag%du3dt    = zero
       Diag%dv3dt    = zero
       Diag%dt3dt    = zero
-!      if (Model%qdiag3d) then
-!        Diag%dq3dt    = zero
+      if (Model%qdiag3d) then
+        Diag%dq3dt    = zero
 !        Diag%upd_mf   = zero
 !        Diag%dwn_mf   = zero
 !        Diag%det_mf   = zero
-!      endif
+      endif
     endif
 
 !

--- a/gfsphysics/GFS_layer/GFS_typedefs.F90
+++ b/gfsphysics/GFS_layer/GFS_typedefs.F90
@@ -1618,7 +1618,6 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: upd_mf (:,:)   => null()  !< instantaneous convective updraft mass flux
     real (kind=kind_phys), pointer :: dwn_mf (:,:)   => null()  !< instantaneous convective downdraft mass flux
     real (kind=kind_phys), pointer :: det_mf (:,:)   => null()  !< instantaneous convective detrainment mass flux
-    real (kind=kind_phys), pointer :: cldcov (:,:)   => null()  !< instantaneous 3D cloud fraction
 !--- F-A MP scheme
 #ifdef CCPP
     real (kind=kind_phys), pointer :: TRAIN  (:,:)   => null()  !< accumulated stratiform T tendency (K s-1)
@@ -5892,7 +5891,6 @@ module GFS_typedefs
 !     allocate (Diag%upd_mf (IM,Model%levs))
 !     allocate (Diag%dwn_mf (IM,Model%levs))
 !     allocate (Diag%det_mf (IM,Model%levs))
-!     allocate (Diag%cldcov (IM,Model%levs))
     endif
 
 !vay-2018
@@ -6089,9 +6087,6 @@ module GFS_typedefs
     Diag%topfsw%upfx0 = zero
     Diag%topflw%upfxc = zero
     Diag%topflw%upfx0 = zero
-    if (Model%ldiag3d) then
-      Diag%cldcov     = zero
-    endif
 
   end subroutine diag_rad_zero
 
@@ -6240,12 +6235,12 @@ module GFS_typedefs
       Diag%du3dt    = zero
       Diag%dv3dt    = zero
       Diag%dt3dt    = zero
-      if (Model%qdiag3d) then
-         Diag%dq3dt    = zero
-      endif
-!     Diag%upd_mf   = zero
-!     Diag%dwn_mf   = zero
-!     Diag%det_mf   = zero
+!      if (Model%qdiag3d) then
+!        Diag%dq3dt    = zero
+!        Diag%upd_mf   = zero
+!        Diag%dwn_mf   = zero
+!        Diag%det_mf   = zero
+!      endif
     endif
 
 !

--- a/stochastic_physics/stochastic_physics_wrapper.F90
+++ b/stochastic_physics/stochastic_physics_wrapper.F90
@@ -29,6 +29,8 @@ module stochastic_physics_wrapper_mod
   real(kind=kind_phys), dimension(:,:), allocatable, save :: facwf
   !emissivity
   real(kind=kind_phys), dimension(:,:), allocatable, save :: semis
+  !roughness length for land
+  real(kind=kind_phys), dimension(:,:), allocatable, save :: zorll
 
   real(kind=kind_phys), dimension(:,:), allocatable, save :: stype
 
@@ -138,6 +140,7 @@ module stochastic_physics_wrapper_mod
           allocate(facsf(1:Atm_block%nblks,maxval(GFS_Control%blksz)))
           allocate(facwf(1:Atm_block%nblks,maxval(GFS_Control%blksz)))
           allocate(semis(1:Atm_block%nblks,maxval(GFS_Control%blksz)))
+          allocate(zorll(1:Atm_block%nblks,maxval(GFS_Control%blksz)))
       endif
 
       do nb=1,Atm_block%nblks
@@ -205,6 +208,7 @@ module stochastic_physics_wrapper_mod
                 facsf(nb,1:GFS_Control%blksz(nb))  = GFS_Data(nb)%Sfcprop%facsf(:)
                 facwf(nb,1:GFS_Control%blksz(nb))  = GFS_Data(nb)%Sfcprop%facwf(:)
                 semis(nb,1:GFS_Control%blksz(nb))  = GFS_Data(nb)%Radtend%semis(:)
+                zorll(nb,1:GFS_Control%blksz(nb))  = GFS_Data(nb)%Sfcprop%zorll(:)
              end do
 
              if (GFS_Control%lsm == GFS_Control%lsm_noah) then
@@ -234,7 +238,7 @@ module stochastic_physics_wrapper_mod
                                GFS_Control%dtf, GFS_Control%kdt, GFS_Control%lndp_each_step,                                  &
                                GFS_Control%n_var_lndp, GFS_Control%lndp_var_list, GFS_Control%lndp_prt_list,                  &
                                sfc_wts, xlon, xlat, stype, GFS_Control%pores, GFS_Control%resid,param_update_flag,            &
-                               smc, slc, stc, vfrac, alvsf, alnsf, alvwf, alnwf, facsf, facwf, snoalb, semis, ierr)
+                               smc, slc, stc, vfrac, alvsf, alnsf, alvwf, alnwf, facsf, facwf, snoalb, semis, zorll, ierr)
              if (ierr/=0)  then
                     write(6,*) 'call to GFS_apply_lndp failed'
                     return
@@ -250,6 +254,7 @@ module stochastic_physics_wrapper_mod
                GFS_Data(nb)%Sfcprop%facsf(:)  = facsf(nb,1:GFS_Control%blksz(nb))
                GFS_Data(nb)%Sfcprop%facwf(:)  = facwf(nb,1:GFS_Control%blksz(nb))
                GFS_Data(nb)%Radtend%semis(:)  = semis(nb,1:GFS_Control%blksz(nb))
+               GFS_Data(nb)%Sfcprop%zorll(:)  = zorll(nb,1:GFS_Control%blksz(nb))
              enddo
 
              if (GFS_Control%lsm == GFS_Control%lsm_noah) then
@@ -400,6 +405,7 @@ module stochastic_physics_wrapper_mod
           if (allocated(facsf)) deallocate(facsf)
           if (allocated(facwf)) deallocate(facwf)
           if (allocated(semis)) deallocate(semis)
+          if (allocated(zorll)) deallocate(zorll)
       endif
       call finalize_stochastic_physics()
    endif


### PR DESCRIPTION
## Description
The perturbation of the ZORLL (roughness length over land) is added.

(Instructions: this, and all subsequent sections of text should be removed and filled in as appropriate.)
Provide a detailed description of what this PR does.  
What bug does it fix, or what feature does it add?  
Is a change of answers expected from this PR?  



### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes #<issue_number>
- fixes noaa-emc/fv3atm/issues/<issue_number>



## Testing

How were these changes tested?  
What compilers / HPCs was it tested with?  
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  
Have the ufs-weather-model regression test been run? On what platform?  
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on noaa-emc/nems/pull/<pr_number>
- waiting on noaa-emc/fv3atm/pull/<pr_number>
