### PR TITLE
A draft PR: use of albedo and emissivity consistently with LSMs with/without fractional grid

### DIFF
--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -87,7 +87,7 @@ module GFS_typedefs
 !    GFS_sfcprop_type        !< surface fields
 !    GFS_coupling_type       !< fields to/from coupling with other components (e.g. land/ice/ocean/etc.)
 !    !---GFS specific containers
-!    GFS_control_type        !< model control parameters
+!    GFS_control_type        !< model control parameters 
 !    GFS_grid_type           !< grid and interpolation related data
 !    GFS_tbd_type            !< to be determined data that doesn't fit in any one container
 !    GFS_cldprop_type        !< cloud fields needed by radiation from physics
@@ -159,7 +159,7 @@ module GFS_typedefs
 !!
   type GFS_statein_type
 
-!--- level geopotential and pressures
+!--- level geopotential and pressures 
     real (kind=kind_phys), pointer :: phii  (:,:) => null()   !< interface geopotential height
     real (kind=kind_phys), pointer :: prsi  (:,:) => null()   !< model level pressure in Pa
     real (kind=kind_phys), pointer :: prsik (:,:) => null()   !< Exner function at interface
@@ -182,7 +182,7 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: smc (:,:)   => null()  !< soil moisture content
     real (kind=kind_phys), pointer :: stc (:,:)   => null()  !< soil temperature content
     real (kind=kind_phys), pointer :: slc (:,:)   => null()  !< soil liquid water content
-
+ 
     contains
       procedure :: create  => statein_create  !<   allocate array data
   end type GFS_statein_type
@@ -222,7 +222,7 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: oceanfrac(:) => null()  !< ocean fraction [0:1]
     real (kind=kind_phys), pointer :: landfrac(:)  => null()  !< land  fraction [0:1]
     real (kind=kind_phys), pointer :: lakefrac(:)  => null()  !< lake  fraction [0:1]
-    real (kind=kind_phys), pointer :: lakedepth(:) => null()  !< lake  depth [ m ]
+    real (kind=kind_phys), pointer :: lakedepth(:) => null()  !< lake  depth [ m ]  
     real (kind=kind_phys), pointer :: tsfc   (:)   => null()  !< surface air temperature in K
                                                               !< [tsea in gbphys.f]
     real (kind=kind_phys), pointer :: tsfco  (:)   => null()  !< sst in K
@@ -240,6 +240,14 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: hprime (:,:) => null()  !< orographic metrics
     real (kind=kind_phys), pointer :: z0base (:)   => null()  !< background or baseline surface roughness length in m
     real (kind=kind_phys), pointer :: semisbase(:) => null()  !< background surface emissivity
+    real (kind=kind_phys), pointer :: sfalb_lnd (:) => null() !< surface albedo over land for LSM
+    real (kind=kind_phys), pointer :: sfalb_ice (:) => null() !< surface albedo over ice for LSM
+    real (kind=kind_phys), pointer :: emis_lnd (:)  => null() !< surface emissivity over land for LSM
+    real (kind=kind_phys), pointer :: emis_ice (:)  => null() !< surface emissivity over ice for LSM
+    real (kind=kind_phys), pointer :: alb_ice  (:)  => null() !< snow-free albedo over ice
+    real (kind=kind_phys), pointer :: alb_snow_ice  (:) => null() !< snow albedo for snow on ice
+    real (kind=kind_phys), pointer :: sfalb_lnd_bck (:) => null() !< snow-free albedo over land
+
 
 !--- In (radiation only)
     real (kind=kind_phys), pointer :: sncovr (:)   => null()  !< snow cover in fraction over land
@@ -261,7 +269,7 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: vtype  (:)   => null()  !< vegetation type
     real (kind=kind_phys), pointer :: stype  (:)   => null()  !< soil type
     real (kind=kind_phys), pointer :: uustar (:)   => null()  !< boundary layer parameter
-    real (kind=kind_phys), pointer :: oro    (:)   => null()  !< orography
+    real (kind=kind_phys), pointer :: oro    (:)   => null()  !< orography 
     real (kind=kind_phys), pointer :: oro_uf (:)   => null()  !< unfiltered orography
     real (kind=kind_phys), pointer :: evap   (:)   => null()  !<
     real (kind=kind_phys), pointer :: hflx   (:)   => null()  !<
@@ -317,10 +325,14 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: smcwtdxy(:)  => null()  !<
     real (kind=kind_phys), pointer :: deeprechxy(:)=> null()  !<
     real (kind=kind_phys), pointer :: rechxy  (:)  => null()  !<
-    real (kind=kind_phys), pointer :: albdvis  (:) => null()  !<
-    real (kind=kind_phys), pointer :: albdnir  (:) => null()  !<
-    real (kind=kind_phys), pointer :: albivis  (:) => null()  !<
-    real (kind=kind_phys), pointer :: albinir  (:) => null()  !<
+    real (kind=kind_phys), pointer :: albdvis_lnd  (:) => null()  !<
+    real (kind=kind_phys), pointer :: albdnir_lnd  (:) => null()  !<
+    real (kind=kind_phys), pointer :: albivis_lnd  (:) => null()  !<
+    real (kind=kind_phys), pointer :: albinir_lnd  (:) => null()  !<
+    real (kind=kind_phys), pointer :: albdvis_ice  (:) => null()  !<
+    real (kind=kind_phys), pointer :: albdnir_ice  (:) => null()  !<
+    real (kind=kind_phys), pointer :: albivis_ice  (:) => null()  !<
+    real (kind=kind_phys), pointer :: albinir_ice  (:) => null()  !<
     real (kind=kind_phys), pointer :: emiss    (:) => null()  !<
 
     real (kind=kind_phys), pointer :: snicexy   (:,:) => null()  !<
@@ -410,7 +422,7 @@ module GFS_typedefs
   type GFS_coupling_type
 
 !--- Out (radiation only)
-    real (kind=kind_phys), pointer :: nirbmdi(:)     => null()   !< sfc nir beam sw downward flux (w/m2)
+    real (kind=kind_phys), pointer :: nirbmdi(:)     => null()   !< sfc nir beam sw downward flux (w/m2) 
     real (kind=kind_phys), pointer :: nirdfdi(:)     => null()   !< sfc nir diff sw downward flux (w/m2)
     real (kind=kind_phys), pointer :: visbmdi(:)     => null()   !< sfc uv+vis beam sw downward flux (w/m2)
     real (kind=kind_phys), pointer :: visdfdi(:)     => null()   !< sfc uv+vis diff sw downward flux (w/m2)
@@ -447,7 +459,7 @@ module GFS_typedefs
 !--- outgoing accumulated quantities
     real (kind=kind_phys), pointer :: rain_cpl  (:)  => null()   !< total rain precipitation
     real (kind=kind_phys), pointer :: rainc_cpl (:)  => null()   !< convective rain precipitation
-    real (kind=kind_phys), pointer :: snow_cpl  (:)  => null()   !< total snow precipitation
+    real (kind=kind_phys), pointer :: snow_cpl  (:)  => null()   !< total snow precipitation  
     real (kind=kind_phys), pointer :: dusfc_cpl (:)  => null()   !< sfc u momentum flux
     real (kind=kind_phys), pointer :: dvsfc_cpl (:)  => null()   !< sfc v momentum flux
     real (kind=kind_phys), pointer :: dtsfc_cpl (:)  => null()   !< sfc sensible heat flux
@@ -496,7 +508,7 @@ module GFS_typedefs
     !--- cellular automata
     real (kind=kind_phys), pointer :: ca1      (:)   => null() !
     real (kind=kind_phys), pointer :: ca2      (:)   => null() !
-    real (kind=kind_phys), pointer :: ca3      (:)   => null() !
+    real (kind=kind_phys), pointer :: ca3      (:)   => null() !  
     real (kind=kind_phys), pointer :: ca_deep  (:)   => null() !
     real (kind=kind_phys), pointer :: ca_turb  (:)   => null() !
     real (kind=kind_phys), pointer :: ca_shal  (:)   => null() !
@@ -530,7 +542,7 @@ module GFS_typedefs
 !----------------------------------------------------------------------------------
 ! GFS_control_type
 !   model control parameters input from a namelist and/or derived from others
-!   list of those that can be modified during the run are at the bottom of the list
+!   list of those that can be modified during the run are at the bottom of the list 
 !----------------------------------------------------------------------------------
 !! \section arg_table_GFS_control_type
 !! \htmlinclude GFS_control_type.html
@@ -545,7 +557,7 @@ module GFS_typedefs
     integer              :: nlunit          !< unit for namelist
     character(len=64)    :: fn_nml          !< namelist filename for surface data cycling
     character(len=256), pointer :: input_nml_file(:) !< character string containing full namelist
-                                                     !< for use with internal file reads
+                                                   !< for use with internal file reads
     integer              :: input_nml_file_length    !< length (number of lines) in namelist for internal reads
     integer              :: logunit
     real(kind=kind_phys) :: fhzero          !< hours between clearing of diagnostic buckets
@@ -572,9 +584,9 @@ module GFS_typedefs
     integer              :: nx              !< number of points in the i-dir for this MPI-domain
     integer              :: ny              !< number of points in the j-dir for this MPI-domain
     integer              :: levs            !< number of vertical levels
-    !--- ak/bk for pressure level calculations
-    real(kind=kind_phys), pointer :: ak(:)  !< from surface (k=1) to TOA (k=levs)
-    real(kind=kind_phys), pointer :: bk(:)  !< from surface (k=1) to TOA (k=levs)
+    !--- ak/bk for pressure level calculations                                                                                                                                                                                             
+    real(kind=kind_phys), pointer :: ak(:)  !< from surface (k=1) to TOA (k=levs)                                                                                                                                                          
+    real(kind=kind_phys), pointer :: bk(:)  !< from surface (k=1) to TOA (k=levs)   
     integer              :: levsp1          !< number of vertical levels plus one
     integer              :: levsm1          !< number of vertical levels minus one
     integer              :: cnx             !< number of points in the i-dir for this cubed-sphere face
@@ -631,12 +643,12 @@ module GFS_typedefs
     integer              :: ico2            !< prescribed global mean value (old opernl)
     integer              :: ialb            !< use climatology alb, based on sfc type
                                             !< 1 => use modis based alb
-    integer              :: iems            !< use fixed value of 1.0
+    integer              :: iems            !< use value of 1.0 or 2.(use LSM emiss)
     integer              :: iaer            !< default aerosol effect in sw only
     integer              :: icliq_sw        !< sw optical property for liquid clouds
     integer              :: icice_sw        !< sw optical property for ice clouds
     integer              :: icliq_lw        !< lw optical property for liquid clouds
-    integer              :: icice_lw        !< lw optical property for ice clouds
+    integer              :: icice_lw        !< lw optical property for ice clouds 
     integer              :: iovr            !< max-random overlap clouds for sw & lw (maximum of both)
     integer              :: ictm            !< ictm=0 => use data at initial cond time, if not
                                             !<           available; use latest; no extrapolation.
@@ -644,7 +656,7 @@ module GFS_typedefs
                                             !<           available; use latest; do extrapolation.
                                             !< ictm=yyyy0 => use yyyy data for the forecast time;
                                             !<           no extrapolation.
-                                            !< ictm=yyyy1 = > use yyyy data for the fcst. If needed,
+                                            !< ictm=yyyy1 = > use yyyy data for the fcst. If needed, 
                                             !<           do extrapolation to match the fcst time.
                                             !< ictm=-1 => use user provided external data for
                                             !<           the fcst time; no extrapolation.
@@ -655,13 +667,13 @@ module GFS_typedefs
                                             !< =1 => sub-grid cloud with prescribed seeds
                                             !< =2 => sub-grid cloud with randomly generated
                                             !< seeds
-    integer              :: idcor           !< Decorrelation length type for overlap assumption
-                                            !< =0 => Use constant decorrelation length, decorr_con
-                                            !< =1 => Use spatially varying decorrelation length (Hogan et al. 2010)
-                                            !< =2 => Use spatially and temporally varyint decorrelation length (Oreopoulos et al. 2012)
-    real(kind_phys)      :: dcorr_con       !< Decorrelation length constant (km) (if idcor = 0)
+    integer              :: idcor           !< Decorrelation length type for overlap assumption                                                                                               
+                                            !< =0 => Use constant decorrelation length, decorr_con                                                                                            
+                                            !< =1 => Use spatially varying decorrelation length (Hogan et al. 2010)                                                                           
+                                            !< =2 => Use spatially and temporally varyint decorrelation length (Oreopoulos et al. 2012)                                                       
+    real(kind_phys)      :: dcorr_con       !< Decorrelation length constant (km) (if idcor = 0) 
     logical              :: crick_proof     !< CRICK-Proof cloud water
-    logical              :: ccnorm          !< Cloud condensate normalized by cloud cover
+    logical              :: ccnorm          !< Cloud condensate normalized by cloud cover 
     logical              :: norad_precip    !< radiation precip flag for Ferrier/Moorthi
     logical              :: lwhtr           !< flag to output lw heating rate (Radtend%lwhc)
     logical              :: swhtr           !< flag to output sw heating rate (Radtend%swhc)
@@ -679,9 +691,9 @@ module GFS_typedefs
     character(len=128)   :: sw_file_clouds          !< RRTMGP file containing coefficients used to compute clouds optical properties
     integer              :: rrtmgp_nBandsSW         !< Number of RRTMGP SW bands.
     integer              :: rrtmgp_nGptsSW          !< Number of RRTMGP SW spectral points.
-    logical              :: doG_cldoptics           !< Use legacy RRTMG cloud-optics?
-    logical              :: doGP_cldoptics_PADE     !< Use RRTMGP cloud-optics: PADE approximation?
-    logical              :: doGP_cldoptics_LUT      !< Use RRTMGP cloud-optics: LUTs?
+    logical              :: doG_cldoptics           !< Use legacy RRTMG cloud-optics?                                             
+    logical              :: doGP_cldoptics_PADE     !< Use RRTMGP cloud-optics: PADE approximation?                                             
+    logical              :: doGP_cldoptics_LUT      !< Use RRTMGP cloud-optics: LUTs?                                             
     integer              :: rrtmgp_nrghice          !< Number of ice-roughness categories
     integer              :: rrtmgp_nGauss_ang       !< Number of angles used in Gaussian quadrature
     logical              :: do_GPsw_Glw             !< If set to true use rrtmgp for SW calculation, rrtmg for LW.
@@ -690,7 +702,7 @@ module GFS_typedefs
     logical              :: doGP_lwscat             !< If true, include scattering in longwave cloud-optics, only compatible w/ GP cloud-optics
 
 !--- microphysical switch
-    integer              :: ncld                           !< choice of cloud scheme
+    integer              :: ncld            !< choice of cloud scheme
     logical              :: convert_dry_rho = .false.      !< flag for converting number concentrations from moist to dry
                                                            !< this flag will no longer be needed once the CCPP standard
                                                            !< names and the CCPP framework logic have been augmented to
@@ -724,7 +736,7 @@ module GFS_typedefs
     integer              :: fprcp              !< no prognostic rain and snow (MG)
     integer              :: pdfflag            !< pdf flag for MG macrophysics
     real(kind=kind_phys) :: mg_dcs             !< Morrison-Gettelman microphysics parameters
-    real(kind=kind_phys) :: mg_qcvar
+    real(kind=kind_phys) :: mg_qcvar      
     real(kind=kind_phys) :: mg_ts_auto_ice(2)  !< ice auto conversion time scale
     real(kind=kind_phys) :: mg_rhmini          !< relative humidity threshold parameter for nucleating ice
 
@@ -765,7 +777,7 @@ module GFS_typedefs
     real(kind=kind_phys) :: ttendlim        !< temperature tendency limiter per time step in K/s
 
     !--- GFDL microphysical paramters
-    logical              :: lgfdlmprad      !< flag for GFDL mp scheme and radiation consistency
+    logical              :: lgfdlmprad      !< flag for GFDL mp scheme and radiation consistency 
 
     !--- Thompson,GFDL mp parameter
     logical              :: lrefres          !< flag for radar reflectivity in restart file
@@ -777,7 +789,7 @@ module GFS_typedefs
     integer              :: lsm_ruc=3       !< flag for RUC land surface model
     integer              :: lsm_noah_wrfv4 = 4 !< flag for NOAH land surface from WRF v4.0
     integer              :: lsoil           !< number of soil layers
-    integer              :: ivegsrc         !< ivegsrc = 0   => USGS,
+    integer              :: ivegsrc         !< ivegsrc = 0   => USGS, 
                                             !< ivegsrc = 1   => IGBP (20 category)
                                             !< ivegsrc = 2   => UMD  (13 category)
                                             !< ivegsrc = 3   => NLCD40 (40 category, NOAH WRFv4 only)
@@ -828,7 +840,7 @@ module GFS_typedefs
     logical              :: pert_cd         !< flag for perturbing the surface drag coefficient for momentum in surface layer scheme (1 = True)
     integer              :: ntsflg          !< flag for updating skin temperature in the GFDL surface layer scheme
     real(kind=kind_phys) :: sfenth          !< enthalpy flux factor 0 zot via charnock ..>0 zot enhanced>15m/s
-
+    
 !--- flake model parameters
     integer              :: lkm             !< flag for flake model
 
@@ -882,9 +894,8 @@ module GFS_typedefs
     logical              :: dspheat         !< flag for tke dissipative heating
     logical              :: hurr_pbl        !< flag for hurricane-specific options in PBL scheme
     logical              :: lheatstrg       !< flag for canopy heat storage parameterization
-    logical              :: cnvcld
+    logical              :: cnvcld        
     logical              :: random_clds     !< flag controls whether clouds are random
-
     logical              :: shal_cnv        !< flag for calling shallow convection
     logical              :: do_deep         !< whether to do deep convection
     integer              :: imfshalcnv      !< flag for mass-flux shallow convection scheme
@@ -929,11 +940,11 @@ module GFS_typedefs
                                             !< workfunction for RAS
     real(kind=kind_phys) :: cdmbgwd(4)      !< multiplication factors for cdmb, gwd and NS gwd, tke based enhancement
     real(kind=kind_phys) :: sup             !< supersaturation in pdf cloud when t is very low
-    real(kind=kind_phys) :: ctei_rm(2)      !< critical cloud top entrainment instability criteria
+    real(kind=kind_phys) :: ctei_rm(2)      !< critical cloud top entrainment instability criteria 
                                             !< (used if mstrat=.true.)
     real(kind=kind_phys) :: crtrh(3)        !< critical relative humidity at the surface
                                             !< PBL top and at the top of the atmosphere
-    real(kind=kind_phys) :: dlqf(2)         !< factor for cloud condensate detrainment
+    real(kind=kind_phys) :: dlqf(2)         !< factor for cloud condensate detrainment 
                                             !< from cloud edges for RAS
     real(kind=kind_phys) :: psauras(2)      !< [in] auto conversion coeff from ice to snow in ras
     real(kind=kind_phys) :: prauras(2)      !< [in] auto conversion coeff from cloud to rain in ras
@@ -1017,7 +1028,7 @@ module GFS_typedefs
                                             !< nstf_name(5) : zsea2 in mm
 !--- fractional grid
     logical              :: frac_grid       !< flag for fractional grid
-    logical              :: ignore_lake     !< flag for ignoring lakes
+    logical              :: ignore_lake     !< flag for ignoring lakes 
     real(kind=kind_phys) :: min_lakeice     !< minimum lake ice value
     real(kind=kind_phys) :: min_seaice      !< minimum sea  ice value
     real(kind=kind_phys) :: min_lake_height !< minimum lake height value
@@ -1051,10 +1062,10 @@ module GFS_typedefs
     integer              :: ncells          !< cellular automata finer grid
     integer              :: nca_g           !< number of independent cellular automata
     integer              :: nlives_g        !< cellular automata lifetime
-    integer              :: ncells_g        !< cellular automata finer grid
-    real(kind=kind_phys) :: nfracseed       !< cellular automata seed probability
+    integer              :: ncells_g        !< cellular automata finer grid  
+    real(kind=kind_phys) :: nfracseed       !< cellular automata seed probability 
     integer              :: nseed           !< cellular automata seed frequency
-    integer              :: nseed_g         !< cellular automata seed frequency
+    integer              :: nseed_g         !< cellular automata seed frequency    
     logical              :: do_ca           !< cellular automata main switch
     logical              :: ca_sgs          !< switch for sgs ca
     logical              :: ca_global       !< switch for global ca
@@ -1079,10 +1090,10 @@ module GFS_typedefs
     logical              :: lndp_each_step    ! flag to indicate that land perturbations are applied at every time step,
                                               ! otherwise they are applied only after gcycle is run
     character(len=3)     :: lndp_var_list(6)  ! dimension here must match  n_var_max_lndp in  stochy_nml_def
-    real(kind=kind_phys) :: lndp_prt_list(6)  ! dimension here must match  n_var_max_lndp in  stochy_nml_def
-                                              ! also previous code had dimension 5 for each pert, to allow
-                                              ! multiple patterns. It wasn't fully coded (and wouldn't have worked
-                                              ! with nlndp>1, so I just dropped it). If we want to code it properly,
+    real(kind=kind_phys) :: lndp_prt_list(6)  ! dimension here must match  n_var_max_lndp in  stochy_nml_def 
+                                              ! also previous code had dimension 5 for each pert, to allow 
+                                              ! multiple patterns. It wasn't fully coded (and wouldn't have worked 
+                                              ! with nlndp>1, so I just dropped it). If we want to code it properly, 
                                               ! we'd need to make this dim(6,5).
 !--- tracer handling
     character(len=32), pointer :: tracer_names(:) !< array of initialized tracers from dynamic core
@@ -1142,7 +1153,7 @@ module GFS_typedefs
     integer              :: ncnvwind        !< the index of surface wind enhancement due to convection for MYNN SFC and RAS CNV in phy f2d
 
 !--- debug flag
-    logical              :: debug
+    logical              :: debug         
     logical              :: pre_rad         !< flag for testing purpose
 
 !--- variables modified at each time step
@@ -1155,7 +1166,7 @@ module GFS_typedefs
     real(kind=kind_phys) :: slag            !< equation of time ( radian )                  [set via radupdate]
     real(kind=kind_phys) :: sdec            !< sin of the solar declination angle           [set via radupdate]
     real(kind=kind_phys) :: cdec            !< cos of the solar declination angle           [set via radupdate]
-    real(kind=kind_phys) :: clstp           !< index used by cnvc90 (for convective clouds)
+    real(kind=kind_phys) :: clstp           !< index used by cnvc90 (for convective clouds) 
                                             !< legacy stuff - does not affect forecast
     real(kind=kind_phys) :: phour           !< previous forecast hour
     real(kind=kind_phys) :: fhour           !< current forecast hour
@@ -1201,11 +1212,11 @@ module GFS_typedefs
 !! \htmlinclude GFS_grid_type.html
 !!
   type GFS_grid_type
-
+ 
     real (kind=kind_phys), pointer :: xlon   (:)    => null()   !< grid longitude in radians, ok for both 0->2pi
                                                                 !! or -pi -> +pi ranges
     real (kind=kind_phys), pointer :: xlat   (:)    => null()   !< grid latitude in radians, default to pi/2 ->
-                                                                !! -pi/2 range, otherwise adj in subr called
+                                                                !! -pi/2 range, otherwise adj in subr called 
     real (kind=kind_phys), pointer :: xlat_d (:)    => null()   !< grid latitude in degrees, default to 90 ->
                                                                 !! -90 range, otherwise adj in subr called
     real (kind=kind_phys), pointer :: xlon_d (:)    => null()   !< grid longitude in degrees, default to 0 ->
@@ -1320,18 +1331,18 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: cov        (:,:)   => null()  !
 
     !--- MYJ schemes saved variables (from previous time step)
-    real (kind=kind_phys), pointer :: phy_myj_qsfc(:)    => null()  !
-    real (kind=kind_phys), pointer :: phy_myj_thz0(:)    => null()  !
-    real (kind=kind_phys), pointer :: phy_myj_qz0(:)     => null()  !
-    real (kind=kind_phys), pointer :: phy_myj_uz0(:)     => null()  !
-    real (kind=kind_phys), pointer :: phy_myj_vz0(:)     => null()  !
-    real (kind=kind_phys), pointer :: phy_myj_akhs(:)    => null()  !
-    real (kind=kind_phys), pointer :: phy_myj_akms(:)    => null()  !
-    real (kind=kind_phys), pointer :: phy_myj_chkqlm(:)  => null()  !
-    real (kind=kind_phys), pointer :: phy_myj_elflx(:)   => null()  !
-    real (kind=kind_phys), pointer :: phy_myj_a1u(:)     => null()  !
-    real (kind=kind_phys), pointer :: phy_myj_a1t(:)     => null()  !
-    real (kind=kind_phys), pointer :: phy_myj_a1q(:)     => null()  !
+    real (kind=kind_phys), pointer :: phy_myj_qsfc(:)    => null()  ! 
+    real (kind=kind_phys), pointer :: phy_myj_thz0(:)    => null()  ! 
+    real (kind=kind_phys), pointer :: phy_myj_qz0(:)     => null()  ! 
+    real (kind=kind_phys), pointer :: phy_myj_uz0(:)     => null()  ! 
+    real (kind=kind_phys), pointer :: phy_myj_vz0(:)     => null()  ! 
+    real (kind=kind_phys), pointer :: phy_myj_akhs(:)    => null()  ! 
+    real (kind=kind_phys), pointer :: phy_myj_akms(:)    => null()  ! 
+    real (kind=kind_phys), pointer :: phy_myj_chkqlm(:)  => null()  ! 
+    real (kind=kind_phys), pointer :: phy_myj_elflx(:)   => null()  ! 
+    real (kind=kind_phys), pointer :: phy_myj_a1u(:)     => null()  ! 
+    real (kind=kind_phys), pointer :: phy_myj_a1t(:)     => null()  ! 
+    real (kind=kind_phys), pointer :: phy_myj_a1q(:)     => null()  ! 
 
     contains
       procedure :: create  => tbd_create  !<   allocate array data
@@ -1340,7 +1351,7 @@ module GFS_typedefs
 
 !------------------------------------------------------------------
 ! GFS_cldprop_type
-!  cloud properties and tendencies needed by radiation from physics
+!  cloud properties and tendencies needed by radiation from physics 
 !------------------------------------------------------------------
 !! \section arg_table_GFS_cldprop_type
 !! \htmlinclude GFS_cldprop_type.html
@@ -1389,7 +1400,7 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: sfalb (:)    => null()  !< mean surface diffused sw albedo
 
     real (kind=kind_phys), pointer :: coszen(:)    => null()  !< mean cos of zenith angle over rad call period
-    real (kind=kind_phys), pointer :: tsflw (:)    => null()  !< surface air temp during lw calculation in k
+    real (kind=kind_phys), pointer :: tsflw (:)    => null()  !< surface air temp during lw calculation in k 
     real (kind=kind_phys), pointer :: semis (:)    => null()  !< surface lw emissivity in fraction
 
 !--- In/Out (???) (radiaition only)
@@ -1406,7 +1417,7 @@ module GFS_typedefs
 
 !----------------------------------------------------------------
 ! GFS_diag_type
-!  internal diagnostic type used as arguments to gbphys and grrad
+!  internal diagnostic type used as arguments to gbphys and grrad 
 !----------------------------------------------------------------
 !! \section arg_table_GFS_diag_type
 !! \htmlinclude GFS_diag_type.html
@@ -1523,9 +1534,9 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: tdomip (:)     => null()   !< dominant accumulated sleet type
     real (kind=kind_phys), pointer :: tdoms  (:)     => null()   !< dominant accumulated snow type
 
-    real (kind=kind_phys), pointer :: ca1      (:)   => null() !
+    real (kind=kind_phys), pointer :: ca1      (:)   => null() ! 
     real (kind=kind_phys), pointer :: ca2      (:)   => null() !
-    real (kind=kind_phys), pointer :: ca3      (:)   => null() !
+    real (kind=kind_phys), pointer :: ca3      (:)   => null() ! 
     real (kind=kind_phys), pointer :: ca_deep  (:)   => null()   !< cellular automata fraction
     real (kind=kind_phys), pointer :: ca_turb  (:)   => null()   !< cellular automata fraction
     real (kind=kind_phys), pointer :: ca_shal  (:)   => null()   !< cellular automata fraction
@@ -1552,9 +1563,9 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: dwn_mf (:,:)   => null()  !< instantaneous convective downdraft mass flux
     real (kind=kind_phys), pointer :: det_mf (:,:)   => null()  !< instantaneous convective detrainment mass flux
 !--- F-A MP scheme
-    real (kind=kind_phys), pointer :: train  (:,:)   => null()  !< accumulated stratiform T tendency (K s-1)
-    real (kind=kind_phys), pointer :: cldfra (:,:)   => null()  !< instantaneous 3D cloud fraction
-    !--- MP quantities for 3D diagnositics
+    real (kind=kind_phys), pointer :: TRAIN  (:,:)   => null()  !< accumulated stratiform T tendency (K s-1)
+    real (kind=kind_phys), pointer :: cldfra  (:,:)   => null()  !< instantaneous 3D cloud fraction
+    !--- MP quantities for 3D diagnositics 
     real (kind=kind_phys), pointer :: refl_10cm(:,:) => null()  !< instantaneous refl_10cm
 !
 !---vay-2018 UGWP-diagnostics instantaneous
@@ -1626,15 +1637,15 @@ module GFS_typedefs
 
     real (kind=kind_phys), pointer :: gwp_scheat(:,:) => null()  ! instant shal-conv heat tendency
     real (kind=kind_phys), pointer :: gwp_dcheat(:,:) => null()  ! instant deep-conv heat tendency
-    real (kind=kind_phys), pointer :: gwp_precip(:)   => null()  ! total precip rates
-    integer , pointer              :: gwp_klevs(:,:)  => null()  ! instant levels for GW-launches
-    real (kind=kind_phys), pointer :: gwp_fgf(:)      => null()  ! fgf triggers
-    real (kind=kind_phys), pointer :: gwp_okw(:)      => null()  ! okw triggers
+    real (kind=kind_phys), pointer :: gwp_precip(:) => null()    ! total precip rates
+    integer , pointer              :: gwp_klevs(:,:)=> null()    ! instant levels for GW-launches
+    real (kind=kind_phys), pointer :: gwp_fgf(:)    => null()    ! fgf triggers
+    real (kind=kind_phys), pointer :: gwp_okw(:)    => null()    ! okw triggers
 
-    real (kind=kind_phys), pointer :: gwp_ax(:,:)    => null()   ! instant total UGWP tend m/s/s EW
-    real (kind=kind_phys), pointer :: gwp_ay(:,:)    => null()   ! instant total UGWP tend m/s/s NS
-    real (kind=kind_phys), pointer :: gwp_dtdt(:,:)  => null()   ! instant total heat tend   K/s
-    real (kind=kind_phys), pointer :: gwp_kdis(:,:)  => null()   ! instant total eddy mixing m2/s
+    real (kind=kind_phys), pointer :: gwp_ax(:,:)   => null()    ! instant total UGWP tend m/s/s EW
+    real (kind=kind_phys), pointer :: gwp_ay(:,:)   => null()    ! instant total UGWP tend m/s/s NS
+    real (kind=kind_phys), pointer :: gwp_dtdt(:,:) => null()    ! instant total heat tend   K/s
+    real (kind=kind_phys), pointer :: gwp_kdis(:,:) => null()    ! instant total eddy mixing m2/s
     real (kind=kind_phys), pointer :: gwp_axc(:,:)   => null()   ! instant con-UGWP tend m/s/s EW
     real (kind=kind_phys), pointer :: gwp_ayc(:,:)   => null()   ! instant con-UGWP tend m/s/s NS
     real (kind=kind_phys), pointer :: gwp_axo(:,:)   => null()   ! instant oro-UGWP tend m/s/s EW
@@ -1642,18 +1653,18 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: gwp_axf(:,:)   => null()   ! instant jet-UGWP tend m/s/s EW
     real (kind=kind_phys), pointer :: gwp_ayf(:,:)   => null()   ! instant jet-UGWP tend m/s/s NS
 
-    real (kind=kind_phys), pointer :: uav_ugwp(:,:)  => null()   ! aver  wind UAV from physics
-    real (kind=kind_phys), pointer :: tav_ugwp(:,:)  => null()   ! aver  temp UAV from physics
-    real (kind=kind_phys), pointer :: du3dt_dyn(:,:) => null()   ! U Tend-dynamics "In"-"PhysOut"
+    real (kind=kind_phys), pointer :: uav_ugwp(:,:)   => null()   ! aver  wind UAV from physics
+    real (kind=kind_phys), pointer :: tav_ugwp(:,:)   => null()   ! aver  temp UAV from physics
+    real (kind=kind_phys), pointer :: du3dt_dyn(:,:)  => null()   ! U Tend-dynamics "In"-"PhysOut"
 
 !--- COODRE ORO diagnostics
-    real (kind=kind_phys), pointer :: zmtb(:)        => null()   !
-    real (kind=kind_phys), pointer :: zogw(:)        => null()   !
+    real (kind=kind_phys), pointer :: zmtb(:)         => null()   !
+    real (kind=kind_phys), pointer :: zogw(:)         => null()   !
     real (kind=kind_phys), pointer :: zlwb(:)        => null()   !
     real (kind=kind_phys), pointer :: tau_ogw(:)     => null()   !
     real (kind=kind_phys), pointer :: tau_ngw(:)     => null()   !
-    real (kind=kind_phys), pointer :: tau_mtb(:)     => null()   !
-    real (kind=kind_phys), pointer :: tau_tofd(:)    => null()   !
+    real (kind=kind_phys), pointer :: tau_mtb(:)      => null()   !
+    real (kind=kind_phys), pointer :: tau_tofd(:)     => null()   !
 !---vay-2018 UGWP-diagnostics
 
     !--- Output diagnostics for coupled chemistry
@@ -1988,7 +1999,7 @@ module GFS_typedefs
     real (kind=kind_phys), pointer      :: vdftra(:,:,:)      => null()  !<
     real (kind=kind_phys), pointer      :: vegf1d(:)          => null()  !<
     real (kind=kind_phys)               :: lndp_vgf                      !<
-
+  
     integer, pointer                    :: vegtype(:)         => null()  !<
     real (kind=kind_phys), pointer      :: w_upi(:,:)         => null()  !<
     real (kind=kind_phys), pointer      :: wcbmax(:)          => null()  !<
@@ -2070,7 +2081,7 @@ module GFS_typedefs
     real (kind=kind_phys), pointer      :: fluxswUP_clrsky(:,:)      => null()  !< RRTMGP upward   shortwave clr-sky flux profile
     real (kind=kind_phys), pointer      :: fluxswDOWN_clrsky(:,:)    => null()  !< RRTMGP downward shortwave clr-sky flux profile
     real (kind=kind_phys), pointer      :: fluxlwUP_jac(:,:)         => null()  !< RRTMGP upward Jacobian of longwave flux
-    real (kind=kind_phys), pointer      :: fluxlwDOWN_jac(:,:)       => null()  !< RRTMGP downward Jacobian of longwave flux
+    real (kind=kind_phys), pointer      :: fluxlwDOWN_jac(:,:)       => null()  !< RRTMGP downward Jacobian of longwave flux 
     real (kind=kind_phys), pointer      :: sfc_emiss_byband(:,:)     => null()  !<
     real (kind=kind_phys), pointer      :: sec_diff_byband(:,:)      => null()  !<
     real (kind=kind_phys), pointer      :: sfc_alb_nir_dir(:,:)      => null()  !<
@@ -2166,7 +2177,7 @@ module GFS_typedefs
 !------------------------
 ! GFS_statein_type%create
 !------------------------
-  subroutine statein_create (Statein, IM, Model)
+  subroutine statein_create (Statein, IM, Model) 
     implicit none
 
     class(GFS_statein_type)             :: Statein
@@ -2278,6 +2289,13 @@ module GFS_typedefs
     allocate (Sfcprop%fice     (IM))
 !   allocate (Sfcprop%hprim    (IM))
     allocate (Sfcprop%hprime   (IM,Model%nmtvr))
+    allocate (Sfcprop%emis_lnd (IM))
+    allocate (Sfcprop%emis_ice (IM))
+    allocate (Sfcprop%sfalb_lnd (IM))
+    allocate (Sfcprop%sfalb_ice (IM))
+    allocate (Sfcprop%alb_ice  (IM))
+    allocate (Sfcprop%alb_snow_ice  (IM))
+    allocate (Sfcprop%sfalb_lnd_bck (IM))
 
     Sfcprop%slmsk     = clear_val
     Sfcprop%oceanfrac = clear_val
@@ -2298,6 +2316,13 @@ module GFS_typedefs
     Sfcprop%fice      = clear_val
 !   Sfcprop%hprim     = clear_val
     Sfcprop%hprime    = clear_val
+    Sfcprop%emis_lnd  = clear_val
+    Sfcprop%emis_ice  = clear_val
+    Sfcprop%sfalb_lnd = clear_val
+    Sfcprop%sfalb_ice = clear_val
+    Sfcprop%alb_ice   = clear_val
+    Sfcprop%alb_snow_ice = clear_val
+    Sfcprop%sfalb_lnd_bck= clear_val
 
 !--- In (radiation only)
     allocate (Sfcprop%snoalb (IM))
@@ -2386,9 +2411,9 @@ module GFS_typedefs
     allocate (Sfcprop%th2m(IM))
     allocate (Sfcprop%q2m (IM))
 
-    Sfcprop%t2m  = clear_val
+    Sfcprop%t2m = clear_val
     Sfcprop%th2m = clear_val
-    Sfcprop%q2m  = clear_val
+    Sfcprop%q2m = clear_val
 
     if (Model%nstf_name(1) > 0) then
       allocate (Sfcprop%tref   (IM))
@@ -2473,11 +2498,15 @@ module GFS_typedefs
     allocate (Sfcprop%taussxy  (IM))
     allocate (Sfcprop%smcwtdxy (IM))
     allocate (Sfcprop%deeprechxy (IM))
-    allocate (Sfcprop%rechxy     (IM))
-    allocate (Sfcprop%albdvis    (IM))
-    allocate (Sfcprop%albdnir    (IM))
-    allocate (Sfcprop%albivis    (IM))
-    allocate (Sfcprop%albinir    (IM))
+    allocate (Sfcprop%rechxy    (IM))
+    allocate (Sfcprop%albdvis_lnd (IM))
+    allocate (Sfcprop%albdnir_lnd (IM))
+    allocate (Sfcprop%albivis_lnd (IM))
+    allocate (Sfcprop%albinir_lnd (IM))
+    allocate (Sfcprop%albdvis_ice (IM))
+    allocate (Sfcprop%albdnir_ice (IM))
+    allocate (Sfcprop%albivis_ice (IM))
+    allocate (Sfcprop%albinir_ice (IM))
     allocate (Sfcprop%emiss      (IM))
     allocate (Sfcprop%snicexy    (IM, Model%lsnow_lsm_lbound:Model%lsnow_lsm_ubound))
     allocate (Sfcprop%snliqxy    (IM, Model%lsnow_lsm_lbound:Model%lsnow_lsm_ubound))
@@ -2514,10 +2543,14 @@ module GFS_typedefs
     Sfcprop%smcwtdxy   = clear_val
     Sfcprop%deeprechxy = clear_val
     Sfcprop%rechxy     = clear_val
-    Sfcprop%albdvis    = clear_val
-    Sfcprop%albdnir    = clear_val
-    Sfcprop%albivis    = clear_val
-    Sfcprop%albinir    = clear_val
+    Sfcprop%albdvis_lnd    = clear_val
+    Sfcprop%albdnir_lnd    = clear_val
+    Sfcprop%albivis_lnd    = clear_val
+    Sfcprop%albinir_lnd    = clear_val
+    Sfcprop%albdvis_ice    = clear_val
+    Sfcprop%albdnir_ice    = clear_val
+    Sfcprop%albivis_ice    = clear_val
+    Sfcprop%albinir_ice    = clear_val
     Sfcprop%emiss      = clear_val
 
     Sfcprop%snicexy    = clear_val
@@ -2525,7 +2558,7 @@ module GFS_typedefs
     Sfcprop%tsnoxy     = clear_val
     Sfcprop%smoiseq    = clear_val
     Sfcprop%zsnsoxy    = clear_val
-
+    
     allocate(Sfcprop%draincprv  (IM))
     allocate(Sfcprop%drainncprv (IM))
     allocate(Sfcprop%diceprv    (IM))
@@ -2537,7 +2570,7 @@ module GFS_typedefs
     Sfcprop%diceprv     = clear_val
     Sfcprop%dsnowprv    = clear_val
     Sfcprop%dgraupelprv = clear_val
-
+    
    endif
 
     ! HWRF NOAH LSM allocate and init when used
@@ -2546,16 +2579,16 @@ module GFS_typedefs
       allocate(Sfcprop%snotime(IM))
       Sfcprop%snotime = clear_val
     end if
-
+    
     if (Model%do_myjsfc.or.Model%do_myjpbl.or.(Model%lsm == Model%lsm_noah_wrfv4)) then
       allocate(Sfcprop%z0base(IM))
       Sfcprop%z0base = clear_val
     end if
-    if (Model%lsm == Model%lsm_noah_wrfv4) then
+    !if (Model%lsm == Model%lsm_noah_wrfv4 .or. Model%lsm == Model%lsm_ruc) then
       allocate(Sfcprop%semisbase(IM))
       Sfcprop%semisbase = clear_val
-    end if
-
+    !end if
+    
     if (Model%lsm == Model%lsm_ruc) then
        ! For land surface models with different numbers of levels than the four NOAH levels
        allocate (Sfcprop%wetness         (IM))
@@ -2624,7 +2657,7 @@ module GFS_typedefs
         allocate (Sfcprop%conv_act(IM))
         Sfcprop%conv_act = zero
     end if
-
+    
   end subroutine sfcprop_create
 
 
@@ -2643,12 +2676,12 @@ module GFS_typedefs
     !--- physics in
     allocate (Coupling%nirbmdi (IM))
     allocate (Coupling%nirdfdi (IM))
-    allocate (Coupling%visbmdi (IM))
-    allocate (Coupling%visdfdi (IM))
-    allocate (Coupling%nirbmui (IM))
-    allocate (Coupling%nirdfui (IM))
-    allocate (Coupling%visbmui (IM))
-    allocate (Coupling%visdfui (IM))
+    allocate (Coupling%visbmdi (IM))   
+    allocate (Coupling%visdfdi (IM))   
+    allocate (Coupling%nirbmui (IM))   
+    allocate (Coupling%nirdfui (IM))   
+    allocate (Coupling%visbmui (IM))   
+    allocate (Coupling%visdfui (IM))   
 
     Coupling%nirbmdi = clear_val
     Coupling%nirdfdi = clear_val
@@ -2679,13 +2712,13 @@ module GFS_typedefs
     endif
 
     if (Model%cplflx .or. Model%cplwav) then
-      !--- instantaneous quantities
+      !--- instantaneous quantities 
       allocate (Coupling%u10mi_cpl (IM))
       allocate (Coupling%v10mi_cpl (IM))
 
       Coupling%u10mi_cpl = clear_val
       Coupling%v10mi_cpl = clear_val
-    endif
+    endif 
 
 !   if (Model%cplwav2atm) then
       !--- incoming quantities
@@ -2823,7 +2856,7 @@ module GFS_typedefs
       Coupling%ca_turb   = clear_val
       Coupling%ca_shal   = clear_val
       Coupling%ca_rad    = clear_val
-      Coupling%ca_micro  = clear_val
+      Coupling%ca_micro  = clear_val   
       Coupling%condition = clear_val
     endif
 
@@ -2975,20 +3008,22 @@ module GFS_typedefs
     real(kind=kind_phys) :: fhlwr          = 3600.           !< frequency for longwave radiation (secs)
     integer              :: nhfrad         = 0               !< number of timesteps for which to call radiation on physics timestep (coldstarts)
     integer              :: levr           = -99             !< number of vertical levels for radiation calculations
-    integer              :: nfxr           = 39+6            !< second dimension of input/output array fluxr
-    logical              :: iaerclm        = .false.         !< flag for initializing aero data
+    integer              :: nfxr           = 39+6            !< second dimension of input/output array fluxr   
+    logical              :: iaerclm        = .false.         !< flag for initializing aero data 
     integer              :: iccn           =  0              !< logical to use IN CCN forcing for MG2/3
     integer              :: iflip          =  1              !< iflip - is not the same as flipv
     integer              :: isol           =  0              !< use prescribed solar constant
     integer              :: ico2           =  0              !< prescribed global mean value (old opernl)
     integer              :: ialb           =  0              !< use climatology alb, based on sfc type
-                                                             !< 1 => use modis based alb
-    integer              :: iems           =  0              !< use fixed value of 1.0
+                                                             !< 1 => use modis based alb (RUC lsm)
+                                                             !< 2 => use LSM albedo (Noah MP lsm) 
+    integer              :: iems           =  0              !< 1.0 => Noah lsm 
+                                                             !< 2.0 => Noah MP and RUC lsms
     integer              :: iaer           =  1              !< default aerosol effect in sw only
     integer              :: icliq_sw       =  1              !< sw optical property for liquid clouds
-    integer              :: icice_sw       =  3              !< sw optical property for ice clouds
-    integer              :: icliq_lw       =  1              !< lw optical property for liquid clouds
-    integer              :: icice_lw       =  3              !< lw optical property for ice clouds
+    integer              :: icice_sw       =  3              !< sw optical property for ice clouds 
+    integer              :: icliq_lw       =  1              !< lw optical property for liquid clouds 
+    integer              :: icice_lw       =  3              !< lw optical property for ice clouds 
     integer              :: iovr           =  1              !< cloud-overlap: max-random overlap clouds
     integer              :: ictm           =  1              !< ictm=0 => use data at initial cond time, if not
                                                              !<           available; use latest; no extrapolation.
@@ -2996,7 +3031,7 @@ module GFS_typedefs
                                                              !<           available; use latest; do extrapolation.
                                                              !< ictm=yyyy0 => use yyyy data for the forecast time;
                                                              !<           no extrapolation.
-                                                             !< ictm=yyyy1 = > use yyyy data for the fcst. If needed,
+                                                             !< ictm=yyyy1 = > use yyyy data for the fcst. If needed, 
                                                              !<           do extrapolation to match the fcst time.
                                                              !< ictm=-1 => use user provided external data for
                                                              !<           the fcst time; no extrapolation.
@@ -3013,30 +3048,30 @@ module GFS_typedefs
                                                              !< =2 => Use spatially and temporally varyint decorrelation length (Oreopoulos et al. 2012)
     real(kind_phys)      :: dcorr_con         = 2.5          !< Decorrelation length constant (km) (if idcor = 0)
     logical              :: crick_proof       = .false.      !< CRICK-Proof cloud water
-    logical              :: ccnorm            = .false.      !< Cloud condensate normalized by cloud cover
+    logical              :: ccnorm            = .false.      !< Cloud condensate normalized by cloud cover 
     logical              :: norad_precip      = .false.      !< radiation precip flag for Ferrier/Moorthi
     logical              :: lwhtr             = .true.       !< flag to output lw heating rate (Radtend%lwhc)
     logical              :: swhtr             = .true.       !< flag to output sw heating rate (Radtend%swhc)
-    ! RRTMGP
-    logical              :: do_RRTMGP           = .false.    !< Use RRTMGP?
-    character(len=128)   :: active_gases        = ''         !< Character list of active gases used in RRTMGP
-    integer              :: nGases              = 0          !< Number of active gases
-    character(len=128)   :: rrtmgp_root         = ''         !< Directory of rte+rrtmgp source code
-    character(len=128)   :: lw_file_gas         = ''         !< RRTMGP K-distribution file, coefficients to compute optics for gaseous atmosphere
-    character(len=128)   :: lw_file_clouds      = ''         !< RRTMGP file containing coefficients used to compute clouds optical properties
-    integer              :: rrtmgp_nBandsLW     = 16         !< Number of RRTMGP LW bands.
-    integer              :: rrtmgp_nGptsLW      = 256        !< Number of RRTMGP LW spectral points.
-    character(len=128)   :: sw_file_gas         = ''         !< RRTMGP K-distribution file, coefficients to compute optics for gaseous atmosphere
-    character(len=128)   :: sw_file_clouds      = ''         !< RRTMGP file containing coefficients used to compute clouds optical properties
-    integer              :: rrtmgp_nBandsSW     = 14         !< Number of RRTMGP SW bands.
-    integer              :: rrtmgp_nGptsSW      = 224        !< Number of RRTMGP SW spectral points.
-    logical              :: doG_cldoptics       = .false.    !< Use legacy RRTMG cloud-optics?
+    ! RRTMGP                                                                                                                                                                                                                                                                                                                                             
+    logical              :: do_RRTMGP        = .false.       !< Use RRTMGP?
+    character(len=128)   :: active_gases    = ''             !< Character list of active gases used in RRTMGP
+    integer              :: nGases          = 0              !< Number of active gases
+    character(len=128)   :: rrtmgp_root     = ''             !< Directory of rte+rrtmgp source code
+    character(len=128)   :: lw_file_gas     = ''             !< RRTMGP K-distribution file, coefficients to compute optics for gaseous atmosphere
+    character(len=128)   :: lw_file_clouds  = ''             !< RRTMGP file containing coefficients used to compute clouds optical properties
+    integer              :: rrtmgp_nBandsLW = 16             !< Number of RRTMGP LW bands.
+    integer              :: rrtmgp_nGptsLW  = 256            !< Number of RRTMGP LW spectral points.
+    character(len=128)   :: sw_file_gas     = ''             !< RRTMGP K-distribution file, coefficients to compute optics for gaseous atmosphere
+    character(len=128)   :: sw_file_clouds  = ''             !< RRTMGP file containing coefficients used to compute clouds optical properties
+    integer              :: rrtmgp_nBandsSW = 14             !< Number of RRTMGP SW bands.
+    integer              :: rrtmgp_nGptsSW  = 224            !< Number of RRTMGP SW spectral points.
+    logical              :: doG_cldoptics       = .false.    !< Use legacy RRTMG cloud-optics?                                             
     logical              :: doGP_cldoptics_PADE = .false.    !< Use RRTMGP cloud-optics: PADE approximation?
-    logical              :: doGP_cldoptics_LUT  = .false.    !< Use RRTMGP cloud-optics: LUTs?
-    integer              :: rrtmgp_nrghice      = 0          !< Number of ice-roughness categories
-    integer              :: rrtmgp_nGauss_ang   = 1          !< Number of angles used in Gaussian quadrature
-    logical              :: do_GPsw_Glw         = .false.
-    logical              :: use_LW_jacobian     = .false.    !< Use Jacobian of LW to update LW radiation tendencies.
+    logical              :: doGP_cldoptics_LUT  = .false.    !< Use RRTMGP cloud-optics: LUTs?     
+    integer              :: rrtmgp_nrghice = 0               !< Number of ice-roughness categories
+    integer              :: rrtmgp_nGauss_ang=1              !< Number of angles used in Gaussian quadrature
+    logical              :: do_GPsw_Glw    = .false.     
+    logical              :: use_LW_jacobian = .false.        !< Use Jacobian of LW to update LW radiation tendencies. 
     logical              :: doGP_lwscat         = .false.    !< If true, include scattering in longwave cloud-optics, only compatible w/ GP cloud-optics
 !--- Z-C microphysical parameters
     integer              :: ncld              =  1                 !< choice of cloud scheme
@@ -3087,12 +3122,12 @@ module GFS_typedefs
 
     !--- Thompson microphysical parameters
     logical              :: ltaerosol      = .false.            !< flag for aerosol version
-    logical              :: lradar         = .false.            !< flag for radar reflectivity
+    logical              :: lradar         = .false.            !< flag for radar reflectivity 
     real(kind=kind_phys) :: nsradar_reset  = -999.0             !< seconds between resetting radar reflectivity calculation, set to <0 for every time step
     real(kind=kind_phys) :: ttendlim       = -999.0             !< temperature tendency limiter, set to <0 to deactivate
 
     !--- GFDL microphysical parameters
-    logical              :: lgfdlmprad     = .false.            !< flag for GFDLMP radiation interaction
+    logical              :: lgfdlmprad     = .false.            !< flag for GFDLMP radiation interaction 
 
     !--- Thompson,GFDL microphysical parameter
     logical              :: lrefres        = .false.            !< flag for radar reflectivity in restart file
@@ -3218,8 +3253,8 @@ module GFS_typedefs
                                                                       !<     1: updated version of satmedmf (as of May 2019)
     logical              :: do_deep        = .true.                   !< whether to do deep convection
 
-    logical              :: hwrf_samfdeep     = .false.               !< flag for HWRF SAMF deepcnv scheme
-    logical              :: hwrf_samfshal     = .false.               !< flag for HWRF SAMF shalcnv scheme
+    logical              :: hwrf_samfdeep     = .false.               !< flag for HWRF SAMF deepcnv scheme 
+    logical              :: hwrf_samfshal     = .false.               !< flag for HWRF SAMF shalcnv scheme 
     logical              :: do_mynnedmf       = .false.               !< flag for MYNN-EDMF
     logical              :: do_mynnsfclay     = .false.               !< flag for MYNN Surface Layer Scheme
     ! DH* TODO - move to MYNN namelist section
@@ -3255,11 +3290,11 @@ module GFS_typedefs
     real(kind=kind_phys) :: cdmbgwd(4)     = (/2.0d0,0.25d0,1.0d0,1.0d0/)   !< multiplication factors for cdmb, gwd, and NS gwd, tke based enhancement
     real(kind=kind_phys) :: sup            = 1.0                      !< supersaturation in pdf cloud (IMP_physics=98) when t is very low
                                                                       !< or ice super saturation in SHOC (when do_shoc=.true.)
-    real(kind=kind_phys) :: ctei_rm(2)     = (/10.0d0,10.0d0/)        !< critical cloud top entrainment instability criteria
+    real(kind=kind_phys) :: ctei_rm(2)     = (/10.0d0,10.0d0/)        !< critical cloud top entrainment instability criteria 
                                                                       !< (used if mstrat=.true.)
     real(kind=kind_phys) :: crtrh(3)       = (/0.90d0,0.90d0,0.90d0/) !< critical relative humidity at the surface
                                                                       !< PBL top and at the top of the atmosphere
-    real(kind=kind_phys) :: dlqf(2)        = (/0.0d0,0.0d0/)          !< factor for cloud condensate detrainment
+    real(kind=kind_phys) :: dlqf(2)        = (/0.0d0,0.0d0/)          !< factor for cloud condensate detrainment 
                                                                       !< from cloud edges for RAS
     real(kind=kind_phys) :: psauras(2)     = (/1.0d-3,1.0d-3/)        !< [in] auto conversion coeff from ice to snow in ras
     real(kind=kind_phys) :: prauras(2)     = (/2.0d-3,2.0d-3/)        !< [in] auto conversion coeff from cloud to rain in ras
@@ -3289,7 +3324,7 @@ module GFS_typedefs
                                                              !< cx = min([-0.7 ln(Nccn) + 24]*1.e-4, c0s)
                                                              !< Nccn: CCN number concentration in cm^(-3)
                                                              !< Until a realistic Nccn is provided, Nccns are assumed
-                                                             !< as Nccn=100 for sea and Nccn=1000 for land
+                                                             !< as Nccn=100 for sea and Nccn=1000 for land 
 
 !--- mass flux shallow convection
     real(kind=kind_phys) :: clam_shal      = 0.3             !< c_e for shallow convection (Han and Pan, 2011, eq(6))
@@ -3303,7 +3338,7 @@ module GFS_typedefs
                                                              !< cx = min([-0.7 ln(Nccn) + 24]*1.e-4, c0s)
                                                              !< Nccn: CCN number concentration in cm^(-3)
                                                              !< Until a realistic Nccn is provided, Nccns are assumed
-                                                             !< as Nccn=100 for sea and Nccn=1000 for land
+                                                             !< as Nccn=100 for sea and Nccn=1000 for land 
 
 !--- near surface sea temperature model
     logical              :: nst_anl        = .false.         !< flag for NSSTM analysis in gcycle/sfcsub
@@ -3331,9 +3366,9 @@ module GFS_typedefs
                                                              !< negative when cplwav2atm=.true. - i.e. two way wave coupling
 
 !--- vertical diffusion
-    real(kind=kind_phys) :: xkzm_m         = 1.0d0           !< [in] bkgd_vdif_m  background vertical diffusion for momentum
-    real(kind=kind_phys) :: xkzm_h         = 1.0d0           !< [in] bkgd_vdif_h  background vertical diffusion for heat q
-    real(kind=kind_phys) :: xkzm_s         = 1.0d0           !< [in] bkgd_vdif_s  sigma threshold for background mom. diffusion
+    real(kind=kind_phys) :: xkzm_m         = 1.0d0           !< [in] bkgd_vdif_m  background vertical diffusion for momentum  
+    real(kind=kind_phys) :: xkzm_h         = 1.0d0           !< [in] bkgd_vdif_h  background vertical diffusion for heat q  
+    real(kind=kind_phys) :: xkzm_s         = 1.0d0           !< [in] bkgd_vdif_s  sigma threshold for background mom. diffusion  
     real(kind=kind_phys) :: xkzminv        = 0.3             !< diffusivity in inversion layers
     real(kind=kind_phys) :: moninq_fac     = 1.0             !< turbulence diffusion coefficient factor
     real(kind=kind_phys) :: dspfac         = 1.0             !< tke dissipative heating factor
@@ -3344,7 +3379,7 @@ module GFS_typedefs
     real(kind=kind_phys) :: z0fac          = 0.3
     real(kind=kind_phys) :: e0fac          = 0.5
 
-
+ 
 !---Cellular automaton options
     integer              :: nca            = 1
     integer              :: ncells         = 5
@@ -3363,7 +3398,7 @@ module GFS_typedefs
     logical              :: ca_smooth      = .false.
     real(kind=kind_phys) :: nthresh        = 0.0
     real                 :: ca_amplitude   = 500.
-    integer              :: nsmooth        = 100
+    integer              :: nsmooth        = 100 
     logical              :: ca_closure     = .false.
     logical              :: ca_entr        = .false.
     logical              :: ca_trigger     = .false.
@@ -3441,7 +3476,8 @@ module GFS_typedefs
                           !    GFDL surface layer options
                                lcurr_sf, pert_cd, ntsflg, sfenth,                           &
                           !--- lake model control
-                               lkm,                                                         &
+                               lkm,                                                         &   
+
                           !--- physical parameterizations
                                ras, trans_trac, old_monin, cnvgwd, mstrat, moist_adj,       &
                                cscnv, cal_pre, do_aw, do_shoc, shocaftcnv, shoc_cld,        &
@@ -3492,7 +3528,7 @@ module GFS_typedefs
                                nca, ncells, nlives, nca_g, ncells_g, nlives_g, nfracseed,   &
                                nseed, nseed_g, nthresh, do_ca,                              &
                                ca_sgs, ca_global,iseed_ca,ca_smooth,                        &
-                               nspinup,ca_amplitude,nsmooth,ca_closure,ca_entr,ca_trigger,  &
+                               nspinup,ca_amplitude,nsmooth,ca_closure,ca_entr,ca_trigger,  & 
                           !--- IAU
                                iau_delthrs,iaufhrs,iau_inc_files,iau_filter_increments,     &
                                iau_drymassfixer,                                            &
@@ -3504,7 +3540,7 @@ module GFS_typedefs
                           !--- aerosol scavenging factors ('name:value' string array)
                                fscav_aero
 
-!--- other parameters
+!--- other parameters 
     integer :: nctp    =  0                !< number of cloud types in CS scheme
     logical :: gen_coord_hybrid = .false.  !< for Henry's gen coord
 
@@ -3846,7 +3882,7 @@ module GFS_typedefs
     Model%spec_adv         = spec_adv
     Model%icloud           = icloud
 
-!--- GFDL MP parameters
+!--- gfdl  MP parameters
     Model%lgfdlmprad       = lgfdlmprad
 !--- Thompson,GFDL MP parameter
     Model%lrefres          = lrefres
@@ -3866,7 +3902,6 @@ module GFS_typedefs
       write(0,*) 'Logic error: rdlai = .true. only works with RUC LSM'
       stop
     end if
-
     ! Set surface layers for CCPP physics
     if (lsoil_lsm==-1) then
       Model%lsoil_lsm      = lsoil
@@ -3878,7 +3913,7 @@ module GFS_typedefs
     ! in the RUC LSM init calls; for Noah WRF4, dzs gets initialized in sfc_noah_wrfv4_interstitial
     ! init, and zs doesn't get used at all.
     ! Allocate variables to store depth/thickness of soil layers
-    allocate (Model%zs (Model%lsoil_lsm))
+       allocate (Model%zs(Model%lsoil_lsm))
     allocate (Model%dzs(Model%lsoil_lsm))
     if (Model%lsm==Model%lsm_noah .or. Model%lsm==Model%lsm_noahmp) then
       if (Model%lsoil_lsm/=4) then
@@ -3888,7 +3923,7 @@ module GFS_typedefs
       Model%zs  = (/-0.1_kind_phys, -0.4_kind_phys, -1.0_kind_phys, -2.0_kind_phys/)
       Model%dzs = (/ 0.1_kind_phys,  0.3_kind_phys,  0.6_kind_phys,  1.0_kind_phys/)
     elseif (Model%lsm==Model%lsm_ruc .or. Model%lsm==Model%lsm_noah_wrfv4) then
-      Model%zs  = clear_val
+       Model%zs = clear_val
       Model%dzs = clear_val
     end if
     ! *DH
@@ -3903,13 +3938,13 @@ module GFS_typedefs
     Model%resid    = clear_val
     !
     if (Model%lsm==Model%lsm_noahmp) then
-      if (lsnow_lsm/=3) then
-        write(0,*) 'Logic error: NoahMP expects the maximum number of snow layers to be exactly 3 (see sfc_noahmp_drv.f)'
-        stop
-      else
-        Model%lsnow_lsm        = lsnow_lsm
-        ! Set lower bound for LSM model, runs from negative (above surface) to surface (zero)
-        Model%lsnow_lsm_lbound = -Model%lsnow_lsm+1
+    if (lsnow_lsm /= 3) then
+      write(0,*) 'Logic error: NoahMP expects the maximum number of snow layers to be exactly 3 (see sfc_noahmp_drv.f)'
+      stop
+    else
+      Model%lsnow_lsm        = lsnow_lsm
+      ! Set lower bound for LSM model, runs from negative (above surface) to surface (zero)
+      Model%lsnow_lsm_lbound = -Model%lsnow_lsm+1
         Model%lsnow_lsm_ubound = 0
       end if
     else
@@ -3935,7 +3970,7 @@ module GFS_typedefs
     Model%pert_cd          = pert_cd
     Model%ntsflg           = ntsflg
     Model%sfenth           = sfenth
-
+    
 !--- flake  model parameters
     Model%lkm              = lkm
 
@@ -4056,7 +4091,6 @@ module GFS_typedefs
     Model%coef_ric_l        = coef_ric_l
     Model%coef_ric_s        = coef_ric_s
     ! *DH
-
     Model%gwd_opt           = gwd_opt
     if (Model%gwd_opt==3 .or. Model%gwd_opt==33 .or. &
         Model%gwd_opt==2 .or. Model%gwd_opt==22) then
@@ -4169,8 +4203,8 @@ module GFS_typedefs
     Model%ca_sgs           = ca_sgs
     Model%iseed_ca         = iseed_ca
     Model%ca_smooth        = ca_smooth
-    Model%nspinup          = nspinup
-    Model%nthresh          = nthresh
+    Model%nspinup          = nspinup  
+    Model%nthresh          = nthresh 
     Model%ca_amplitude     = ca_amplitude
     Model%nsmooth          = nsmooth
     Model%ca_closure       = ca_closure
@@ -4312,7 +4346,7 @@ module GFS_typedefs
     Model%sdec             = -9999.
     Model%cdec             = -9999.
     Model%clstp            = -9999
-    rinc(1:5)              = 0
+    rinc(1:5)              = 0 
     call w3difdat(jdat,idat,4,rinc)
     Model%phour            = rinc(4)/con_hr
     Model%fhour            = (rinc(4) + Model%dtp)/con_hr
@@ -4334,7 +4368,7 @@ module GFS_typedefs
 
 !--- BEGIN CODE FROM GFS_PHYSICS_INITIALIZE
 !--- define physcons module variables
-    tem          = con_rerth*con_rerth*(con_pi+con_pi)*con_pi
+    tem     = con_rerth*con_rerth*(con_pi+con_pi)*con_pi
     Model%dxmax  = log(tem/(max_lon*max_lat))
     Model%dxmin  = log(tem/(min_lon*min_lat))
     Model%dxinv  = 1.0d0 / (Model%dxmax-Model%dxmin)
@@ -4343,7 +4377,8 @@ module GFS_typedefs
        'max_lon=',max_lon,' max_lat=',max_lat,' min_lon=',min_lon,' min_lat=',min_lat,       &
        ' rhc_max=',Model%rhcmax
 
-!--- set nrcm
+!--- set nrcm 
+
     if (Model%ras) then
       Model%nrcm = min(nrcmax, Model%levs-1) * (Model%dtp/1200.d0) + 0.10001d0
     else
@@ -4751,7 +4786,7 @@ module GFS_typedefs
     elseif ((Model%npdf3d == 0) .and. (Model%ncnvcld3d == 1)) then
       Model%ncnvw = Model%num_p3d + 1
     endif
-
+ 
 !--- derived totals for phy_f*d
     Model%ntot2d = Model%num_p2d + Model%nshoc_2d
     Model%ntot3d = Model%num_p3d + Model%nshoc_3d + Model%npdf3d + Model%ncnvcld3d
@@ -4833,7 +4868,7 @@ module GFS_typedefs
 
 !--- interface variables
     class(GFS_control_type) :: Model
-
+ 
     if (Model%me == Model%master) then
       print *, ' '
       print *, 'basic control parameters'
@@ -4998,7 +5033,7 @@ module GFS_typedefs
       print *, ' rdlai             : ', Model%rdlai
       print *, ' lsoil_lsm         : ', Model%lsoil_lsm
       if (Model%lsm==Model%lsm_noahmp) then
-        print *, ' lsnow_lsm         : ', Model%lsnow_lsm
+      print *, ' lsnow_lsm         : ', Model%lsnow_lsm
         print *, ' lsnow_lsm_lbound  : ', Model%lsnow_lsm_lbound
         print *, ' lsnow_lsm_ubound  : ', Model%lsnow_lsm_ubound
       end if
@@ -5236,7 +5271,7 @@ module GFS_typedefs
       print *, ' nscfshoc          : ', Model%nscfshoc
       print *, ' '
       print *, 'debug flags'
-      print *, ' debug             : ', Model%debug
+      print *, ' debug             : ', Model%debug 
       print *, ' pre_rad           : ', Model%pre_rad
       print *, ' '
       print *, 'variables modified at each time step'
@@ -5476,30 +5511,30 @@ module GFS_typedefs
     if (Model%do_myjsfc.or.Model%do_myjpbl) then
        !print*,"Allocating all MYJ surface variables:"
        allocate (Tbd%phy_myj_qsfc   (IM))
-       allocate (Tbd%phy_myj_thz0   (IM))
-       allocate (Tbd%phy_myj_qz0    (IM))
-       allocate (Tbd%phy_myj_uz0    (IM))
-       allocate (Tbd%phy_myj_vz0    (IM))
-       allocate (Tbd%phy_myj_akhs   (IM))
-       allocate (Tbd%phy_myj_akms   (IM))
-       allocate (Tbd%phy_myj_chkqlm (IM))
-       allocate (Tbd%phy_myj_elflx  (IM))
-       allocate (Tbd%phy_myj_a1u    (IM))
-       allocate (Tbd%phy_myj_a1t    (IM))
+       allocate (Tbd%phy_myj_thz0   (IM)) 
+       allocate (Tbd%phy_myj_qz0    (IM)) 
+       allocate (Tbd%phy_myj_uz0    (IM)) 
+       allocate (Tbd%phy_myj_vz0    (IM))  
+       allocate (Tbd%phy_myj_akhs   (IM)) 
+       allocate (Tbd%phy_myj_akms   (IM)) 
+       allocate (Tbd%phy_myj_chkqlm (IM)) 
+       allocate (Tbd%phy_myj_elflx  (IM)) 
+       allocate (Tbd%phy_myj_a1u    (IM)) 
+       allocate (Tbd%phy_myj_a1t    (IM)) 
        allocate (Tbd%phy_myj_a1q    (IM))
        !print*,"Allocating all MYJ schemes variables:"
-       Tbd%phy_myj_qsfc   = clear_val
-       Tbd%phy_myj_thz0   = clear_val
-       Tbd%phy_myj_qz0    = clear_val
-       Tbd%phy_myj_uz0    = clear_val
-       Tbd%phy_myj_vz0    = clear_val
-       Tbd%phy_myj_akhs   = clear_val
-       Tbd%phy_myj_akms   = clear_val
-       Tbd%phy_myj_chkqlm = clear_val
-       Tbd%phy_myj_elflx  = clear_val
-       Tbd%phy_myj_a1u    = clear_val
-       Tbd%phy_myj_a1t    = clear_val
-       Tbd%phy_myj_a1q    = clear_val
+       Tbd%phy_myj_qsfc   = clear_val 
+       Tbd%phy_myj_thz0   = clear_val 
+       Tbd%phy_myj_qz0    = clear_val 
+       Tbd%phy_myj_uz0    = clear_val 
+       Tbd%phy_myj_vz0    = clear_val  
+       Tbd%phy_myj_akhs   = clear_val 
+       Tbd%phy_myj_akms   = clear_val 
+       Tbd%phy_myj_chkqlm = clear_val 
+       Tbd%phy_myj_elflx  = clear_val 
+       Tbd%phy_myj_a1u    = clear_val 
+       Tbd%phy_myj_a1t    = clear_val 
+       Tbd%phy_myj_a1q    = clear_val 
     end if
 
   end subroutine tbd_create
@@ -5517,13 +5552,13 @@ module GFS_typedefs
     type(GFS_control_type), intent(in) :: Model
 
     allocate (Cldprop%cv  (IM))
-    allocate (Cldprop%cvt (IM))
+    allocate (Cldprop%cvt (IM)) 
     allocate (Cldprop%cvb (IM))
-
+    
     Cldprop%cv  = clear_val
     Cldprop%cvt = clear_val
     Cldprop%cvb = clear_val
-
+  
   end subroutine cldprop_create
 
 
@@ -5531,14 +5566,14 @@ module GFS_typedefs
 ! GFS_radtend_type%create
 !******************************************
   subroutine radtend_create (Radtend, IM, Model)
-
+                               
     implicit none
-
+       
     class(GFS_radtend_type)            :: Radtend
     integer,                intent(in) :: IM
     type(GFS_control_type), intent(in) :: Model
 
-    !--- Out (radiation only)
+    !--- Out (radiation only) 
     allocate (Radtend%sfcfsw (IM))
     allocate (Radtend%sfcflw (IM))
 
@@ -5550,7 +5585,7 @@ module GFS_typedefs
     Radtend%sfcflw%upfx0 = clear_val
     Radtend%sfcflw%dnfxc = clear_val
     Radtend%sfcflw%dnfx0 = clear_val
-
+         
     allocate (Radtend%htrsw  (IM,Model%levs))
     allocate (Radtend%htrlw  (IM,Model%levs))
     allocate (Radtend%sfalb  (IM))
@@ -5564,12 +5599,12 @@ module GFS_typedefs
     Radtend%coszen = clear_val
     Radtend%tsflw  = clear_val
     Radtend%semis  = clear_val
-
+             
 !--- In/Out (???) (radiation only)
     allocate (Radtend%coszdg (IM))
 
     Radtend%coszdg = clear_val
-
+             
 !--- In/Out (???) (physics only)
     allocate (Radtend%swhc  (IM,Model%levs))
     allocate (Radtend%lwhc  (IM,Model%levs))
@@ -5683,23 +5718,23 @@ module GFS_typedefs
     allocate (Diag%skebv_wts(IM,Model%levs))
     allocate (Diag%sppt_wts(IM,Model%levs))
     allocate (Diag%shum_wts(IM,Model%levs))
-    allocate (Diag%zmtnblck(IM))
+    allocate (Diag%zmtnblck(IM))    
     allocate (Diag%ca1      (IM))
     allocate (Diag%ca2      (IM))
     allocate (Diag%ca3      (IM))
 
     ! F-A MP scheme
     if (Model%imp_physics == Model%imp_physics_fer_hires) then
-     allocate (Diag%train     (IM,Model%levs))
+     allocate (Diag%TRAIN     (IM,Model%levs))
     end if
     allocate (Diag%cldfra     (IM,Model%levs))
 
     allocate (Diag%ca_deep  (IM))
     allocate (Diag%ca_turb  (IM))
     allocate (Diag%ca_shal  (IM))
-    allocate (Diag%ca_rad   (IM))
-    allocate (Diag%ca_micro (IM))
-
+    allocate (Diag%ca_rad (IM))
+    allocate (Diag%ca_micro  (IM))
+    
     !--- 3D diagnostics
     if (Model%ldiag3d) then
       allocate (Diag%du3dt  (IM,Model%levs,8))
@@ -5732,29 +5767,37 @@ module GFS_typedefs
 
     if (Model%ldiag_ugwp) then
       allocate (Diag%du3dt_dyn  (IM,Model%levs) )
+
       allocate (Diag%du3dt_pbl  (IM,Model%levs) )
       allocate (Diag%dv3dt_pbl  (IM,Model%levs) )
       allocate (Diag%dt3dt_pbl  (IM,Model%levs) )
+
       allocate (Diag%du3dt_ogw  (IM,Model%levs) )
       allocate (Diag%dv3dt_ogw  (IM,Model%levs) )
       allocate (Diag%dt3dt_ogw  (IM,Model%levs) )
+
       allocate (Diag%du3dt_mtb  (IM,Model%levs) )
       allocate (Diag%dv3dt_mtb  (IM,Model%levs) )
       allocate (Diag%dt3dt_mtb  (IM,Model%levs) )
+
       allocate (Diag%du3dt_tms  (IM,Model%levs) )
       allocate (Diag%dv3dt_tms  (IM,Model%levs) )
       allocate (Diag%dt3dt_tms  (IM,Model%levs) )
+
       allocate (Diag%du3dt_ngw  (IM,Model%levs) )
       allocate (Diag%dv3dt_ngw  (IM,Model%levs) )
       allocate (Diag%dt3dt_ngw  (IM,Model%levs) )
+
       allocate (Diag%du3dt_cgw  (IM,Model%levs) )
       allocate (Diag%dv3dt_cgw  (IM,Model%levs) )
-      allocate (Diag%dt3dt_moist (IM,Model%levs))
+      allocate (Diag%dt3dt_moist  (IM,Model%levs) )
+
       allocate (Diag%dudt_tot  (IM,Model%levs) )
       allocate (Diag%dvdt_tot  (IM,Model%levs) )
       allocate (Diag%dtdt_tot  (IM,Model%levs) )
-      allocate (Diag%uav_ugwp  (IM,Model%levs) )
-      allocate (Diag%tav_ugwp  (IM,Model%levs) )
+
+       allocate (Diag%uav_ugwp  (IM,Model%levs) )
+       allocate (Diag%tav_ugwp  (IM,Model%levs) )
     endif
 
     if (Model%do_ugwp_v1 .or. Model%gwd_opt==33 .or. Model%gwd_opt==22) then
@@ -5776,7 +5819,7 @@ module GFS_typedefs
       allocate (Diag%dv_ofdcol (IM)           )
     else
       allocate (Diag%dudt_ogw  (IM,Model%levs))
-    end if
+    endif
 
     !--- 3D diagnostics for Thompson MP / GFDL MP
     allocate (Diag%refl_10cm(IM,Model%levs))
@@ -5955,7 +5998,7 @@ module GFS_typedefs
     Diag%zmtnblck   = zero
 
     if (Model%imp_physics == Model%imp_physics_fer_hires) then
-       Diag%train      = zero
+       Diag%TRAIN      = zero
     end if
     Diag%cldfra      = zero
 
@@ -6003,11 +6046,11 @@ module GFS_typedefs
       Diag%dv3dt    = zero
       Diag%dt3dt    = zero
       if (Model%qdiag3d) then
-        Diag%dq3dt    = zero
-!        Diag%upd_mf   = zero
-!        Diag%dwn_mf   = zero
-!        Diag%det_mf   = zero
-      endif
+         Diag%dq3dt    = zero
+!     Diag%upd_mf   = zero
+!     Diag%dwn_mf   = zero
+!     Diag%det_mf   = zero
+    endif
     endif
 
 !
@@ -6045,34 +6088,39 @@ module GFS_typedefs
       Diag%dudt_ogw    = zero
     end if
 
-    if (Model%ldiag_ugwp) then
+    if (Model%ldiag_ugwp)   then
       Diag%du3dt_pbl   = zero
       Diag%dv3dt_pbl   = zero
       Diag%dt3dt_pbl   = zero
       Diag%du3dt_ogw   = zero
       Diag%dv3dt_ogw   = zero
       Diag%dt3dt_ogw   = zero
+
       Diag%du3dt_mtb   = zero
       Diag%dv3dt_mtb   = zero
       Diag%dt3dt_mtb   = zero
+
       Diag%du3dt_tms   = zero
       Diag%dv3dt_tms   = zero
       Diag%dt3dt_tms   = zero
+
       Diag%du3dt_ngw   = zero
       Diag%dv3dt_ngw   = zero
       Diag%dt3dt_ngw   = zero
+
       Diag%du3dt_moist = zero
       Diag%dv3dt_moist = zero
       Diag%dt3dt_moist = zero
+
       Diag%dudt_tot    = zero
       Diag%dvdt_tot    = zero
       Diag%dtdt_tot    = zero
+
       Diag%uav_ugwp    = zero
       Diag%tav_ugwp    = zero
 !COORDE
       Diag%du3dt_dyn   = zero
     endif
-
 !
 !-----------------------------
 
@@ -6462,7 +6510,7 @@ module GFS_typedefs
        allocate (Interstitial%fluxswUP_allsky      (IM, Model%levs+1))
        allocate (Interstitial%fluxswDOWN_allsky    (IM, Model%levs+1))
        allocate (Interstitial%fluxswUP_clrsky      (IM, Model%levs+1))
-       allocate (Interstitial%fluxswDOWN_clrsky    (IM, Model%levs+1))
+       allocate (Interstitial%fluxswDOWN_clrsky    (IM, Model%levs+1))      
        allocate (Interstitial%aerosolslw           (IM, Model%levs, Model%rrtmgp_nBandsLW, NF_AELW))
        allocate (Interstitial%aerosolssw           (IM, Model%levs, Model%rrtmgp_nBandsSW, NF_AESW))
        allocate (Interstitial%cld_frac             (IM, Model%levs))
@@ -6476,7 +6524,7 @@ module GFS_typedefs
        allocate (Interstitial%cld_rerain           (IM, Model%levs))
        allocate (Interstitial%precip_frac          (IM, Model%levs))
        allocate (Interstitial%icseed_lw            (IM))
-       allocate (Interstitial%icseed_sw            (IM))
+       allocate (Interstitial%icseed_sw            (IM))      
        allocate (Interstitial%flxprf_lw            (IM, Model%levs+1))
        allocate (Interstitial%flxprf_sw            (IM, Model%levs+1))
        allocate (Interstitial%sfc_emiss_byband     (Model%rrtmgp_nBandsLW,IM))
@@ -6506,9 +6554,9 @@ module GFS_typedefs
     allocate (Interstitial%tau_oss         (IM))
     allocate (Interstitial%dudt_mtb        (IM,Model%levs))
     allocate (Interstitial%dudt_tms        (IM,Model%levs))
-    allocate (Interstitial%zmtb            (IM)           )
-    allocate (Interstitial%zlwb            (IM)           )
-    allocate (Interstitial%zogw            (IM)           )
+    allocate (Interstitial%zmtb            (IM))
+    allocate (Interstitial%zlwb            (IM))
+    allocate (Interstitial%zogw            (IM))
     allocate (Interstitial%zngw            (IM)           )
 
 ! CIRES UGWP v1
@@ -6621,7 +6669,7 @@ module GFS_typedefs
     Interstitial%nf_aesw          = NF_AESW
     Interstitial%nspc1            = NSPC1
     if (Model%oz_phys .or. Model%oz_phys_2015) then
-      Interstitial%oz_coeffp5     = oz_coeff+5
+    Interstitial%oz_coeffp5       = oz_coeff+5
     else
       Interstitial%oz_coeffp5     = 5
     endif
@@ -6874,7 +6922,7 @@ module GFS_typedefs
       Interstitial%precip_overlap_param = clear_val
       Interstitial%fluxlwDOWN_allsky    = clear_val
       Interstitial%fluxlwUP_clrsky      = clear_val
-      Interstitial%fluxlwDOWN_clrsky    = clear_val
+      Interstitial%fluxlwDOWN_clrsky    = clear_val                
       Interstitial%fluxswUP_allsky      = clear_val
       Interstitial%fluxswDOWN_allsky    = clear_val
       Interstitial%fluxswUP_clrsky      = clear_val
@@ -7501,16 +7549,16 @@ module GFS_typedefs
     write (0,*) 'sum(Interstitial%zt1d            ) = ', sum(Interstitial%zt1d            )
 
 ! UGWP common
-    write (0,*) 'sum(Interstitial%tau_mtb         ) = ', sum(Interstitial%tau_mtb       )
-    write (0,*) 'sum(Interstitial%tau_ogw         ) = ', sum(Interstitial%tau_ogw       )
-    write (0,*) 'sum(Interstitial%tau_tofd        ) = ', sum(Interstitial%tau_tofd      )
-    write (0,*) 'sum(Interstitial%tau_ngw         ) = ', sum(Interstitial%tau_ngw       )
+    write (0,*) 'sum(Interstitial%tau_mtb         ) = ', sum(Interstitial%tau_mtb         )
+    write (0,*) 'sum(Interstitial%tau_ogw         ) = ', sum(Interstitial%tau_ogw         )
+    write (0,*) 'sum(Interstitial%tau_tofd        ) = ', sum(Interstitial%tau_tofd        )
+    write (0,*) 'sum(Interstitial%tau_ngw         ) = ', sum(Interstitial%tau_ngw         )
     write (0,*) 'sum(Interstitial%tau_oss         ) = ', sum(Interstitial%tau_oss       )
     write (0,*) 'sum(Interstitial%dudt_mtb        ) = ', sum(Interstitial%dudt_mtb      )
     write (0,*) 'sum(Interstitial%dudt_tms        ) = ', sum(Interstitial%dudt_tms      )
-    write (0,*) 'sum(Interstitial%zmtb            ) = ', sum(Interstitial%zmtb          )
-    write (0,*) 'sum(Interstitial%zlwb            ) = ', sum(Interstitial%zlwb          )
-    write (0,*) 'sum(Interstitial%zogw            ) = ', sum(Interstitial%zogw          )
+    write (0,*) 'sum(Interstitial%zmtb            ) = ', sum(Interstitial%zmtb            )
+    write (0,*) 'sum(Interstitial%zlwb            ) = ', sum(Interstitial%zlwb            )
+    write (0,*) 'sum(Interstitial%zogw            ) = ', sum(Interstitial%zogw            )
     write (0,*) 'sum(Interstitial%zngw            ) = ', sum(Interstitial%zngw          )
 
 ! UGWP v1

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -244,8 +244,6 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: sfalb_ice (:) => null() !< surface albedo over ice for LSM
     real (kind=kind_phys), pointer :: emis_lnd (:)  => null() !< surface emissivity over land for LSM
     real (kind=kind_phys), pointer :: emis_ice (:)  => null() !< surface emissivity over ice for LSM
-    real (kind=kind_phys), pointer :: alb_ice  (:)  => null() !< snow-free albedo over ice
-    real (kind=kind_phys), pointer :: alb_snow_ice  (:) => null() !< snow albedo for snow on ice
     real (kind=kind_phys), pointer :: sfalb_lnd_bck (:) => null() !< snow-free albedo over land
 
 
@@ -2293,8 +2291,6 @@ module GFS_typedefs
     allocate (Sfcprop%emis_ice (IM))
     allocate (Sfcprop%sfalb_lnd (IM))
     allocate (Sfcprop%sfalb_ice (IM))
-    allocate (Sfcprop%alb_ice  (IM))
-    allocate (Sfcprop%alb_snow_ice  (IM))
     allocate (Sfcprop%sfalb_lnd_bck (IM))
 
     Sfcprop%slmsk     = clear_val
@@ -2320,8 +2316,6 @@ module GFS_typedefs
     Sfcprop%emis_ice  = clear_val
     Sfcprop%sfalb_lnd = clear_val
     Sfcprop%sfalb_ice = clear_val
-    Sfcprop%alb_ice   = clear_val
-    Sfcprop%alb_snow_ice = clear_val
     Sfcprop%sfalb_lnd_bck= clear_val
 
 !--- In (radiation only)

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -331,7 +331,6 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: albdnir_ice  (:) => null()  !<
     real (kind=kind_phys), pointer :: albivis_ice  (:) => null()  !<
     real (kind=kind_phys), pointer :: albinir_ice  (:) => null()  !<
-    real (kind=kind_phys), pointer :: emiss    (:) => null()  !<
 
     real (kind=kind_phys), pointer :: snicexy   (:,:) => null()  !<
     real (kind=kind_phys), pointer :: snliqxy   (:,:) => null()  !<
@@ -700,8 +699,9 @@ module GFS_typedefs
     logical              :: doGP_lwscat             !< If true, include scattering in longwave cloud-optics, only compatible w/ GP cloud-optics
 
 !--- microphysical switch
-    integer              :: ncld            !< choice of cloud scheme
-    logical              :: convert_dry_rho = .false.      !< flag for converting number concentrations from moist to dry
+    integer              :: ncld                           !< choice of cloud scheme
+    logical              :: convert_dry_rho = .true.       !< flag for converting mass/number concentrations from moist to dry
+                                                           !< for physics options that expect dry mass/number concentrations;
                                                            !< this flag will no longer be needed once the CCPP standard
                                                            !< names and the CCPP framework logic have been augmented to
                                                            !< automatically determine whether such conversions are necessary
@@ -2294,10 +2294,6 @@ module GFS_typedefs
 !   allocate (Sfcprop%hprim    (IM))
     allocate (Sfcprop%hprime   (IM,Model%nmtvr))
     allocate (Sfcprop%emis_lnd (IM))
-    allocate (Sfcprop%emis_ice (IM))
-    allocate (Sfcprop%sfalb_lnd (IM))
-    allocate (Sfcprop%sfalb_ice (IM))
-    allocate (Sfcprop%sfalb_lnd_bck (IM))
 
     Sfcprop%slmsk     = clear_val
     Sfcprop%oceanfrac = clear_val
@@ -2319,10 +2315,6 @@ module GFS_typedefs
 !   Sfcprop%hprim     = clear_val
     Sfcprop%hprime    = clear_val
     Sfcprop%emis_lnd  = clear_val
-    Sfcprop%emis_ice  = clear_val
-    Sfcprop%sfalb_lnd = clear_val
-    Sfcprop%sfalb_ice = clear_val
-    Sfcprop%sfalb_lnd_bck= clear_val
 
 !--- In (radiation only)
     allocate (Sfcprop%snoalb (IM))
@@ -2379,6 +2371,14 @@ module GFS_typedefs
     allocate (Sfcprop%sncovr (IM))
     if (Model%lsm == Model%lsm_ruc) then
       allocate (Sfcprop%sncovr_ice (IM))
+      allocate (Sfcprop%emis_ice (IM))
+      allocate (Sfcprop%albdvis_ice (IM))
+      allocate (Sfcprop%albdnir_ice (IM))
+      allocate (Sfcprop%albivis_ice (IM))
+      allocate (Sfcprop%albinir_ice (IM))
+      allocate (Sfcprop%sfalb_lnd (IM))
+      allocate (Sfcprop%sfalb_ice (IM))
+      allocate (Sfcprop%sfalb_lnd_bck (IM))
     end if
     allocate (Sfcprop%canopy (IM))
     allocate (Sfcprop%ffmm   (IM))
@@ -2394,7 +2394,15 @@ module GFS_typedefs
     Sfcprop%weasd  = clear_val
     Sfcprop%sncovr = clear_val
     if (Model%lsm == Model%lsm_ruc) then
-      Sfcprop%sncovr_ice = clear_val
+      Sfcprop%sncovr_ice  = clear_val
+      Sfcprop%emis_ice    = clear_val
+      Sfcprop%albdvis_ice = clear_val
+      Sfcprop%albdnir_ice = clear_val
+      Sfcprop%albivis_ice = clear_val
+      Sfcprop%albinir_ice = clear_val
+      Sfcprop%sfalb_lnd   = clear_val
+      Sfcprop%sfalb_ice   = clear_val
+      Sfcprop%sfalb_lnd_bck = clear_val
     end if
     Sfcprop%canopy = clear_val
     Sfcprop%ffmm   = clear_val
@@ -2460,11 +2468,20 @@ module GFS_typedefs
       allocate(Sfcprop%iceprv    (IM))
       allocate(Sfcprop%snowprv   (IM))
       allocate(Sfcprop%graupelprv(IM))
+      allocate(Sfcprop%albdvis_lnd (IM))
+      allocate(Sfcprop%albdnir_lnd (IM))
+      allocate(Sfcprop%albivis_lnd (IM))
+      allocate(Sfcprop%albinir_lnd (IM))
+
       Sfcprop%raincprv   = clear_val
       Sfcprop%rainncprv  = clear_val
       Sfcprop%iceprv     = clear_val
       Sfcprop%snowprv    = clear_val
       Sfcprop%graupelprv = clear_val
+      Sfcprop%albdvis_lnd = clear_val
+      Sfcprop%albdnir_lnd = clear_val
+      Sfcprop%albivis_lnd = clear_val
+      Sfcprop%albinir_lnd = clear_val
     end if
 ! Noah MP allocate and init when used
 !
@@ -2499,15 +2516,6 @@ module GFS_typedefs
     allocate (Sfcprop%smcwtdxy (IM))
     allocate (Sfcprop%deeprechxy (IM))
     allocate (Sfcprop%rechxy    (IM))
-    allocate (Sfcprop%albdvis_lnd (IM))
-    allocate (Sfcprop%albdnir_lnd (IM))
-    allocate (Sfcprop%albivis_lnd (IM))
-    allocate (Sfcprop%albinir_lnd (IM))
-    allocate (Sfcprop%albdvis_ice (IM))
-    allocate (Sfcprop%albdnir_ice (IM))
-    allocate (Sfcprop%albivis_ice (IM))
-    allocate (Sfcprop%albinir_ice (IM))
-    allocate (Sfcprop%emiss      (IM))
     allocate (Sfcprop%snicexy    (IM, Model%lsnow_lsm_lbound:Model%lsnow_lsm_ubound))
     allocate (Sfcprop%snliqxy    (IM, Model%lsnow_lsm_lbound:Model%lsnow_lsm_ubound))
     allocate (Sfcprop%tsnoxy     (IM, Model%lsnow_lsm_lbound:Model%lsnow_lsm_ubound))
@@ -2543,15 +2551,6 @@ module GFS_typedefs
     Sfcprop%smcwtdxy   = clear_val
     Sfcprop%deeprechxy = clear_val
     Sfcprop%rechxy     = clear_val
-    Sfcprop%albdvis_lnd    = clear_val
-    Sfcprop%albdnir_lnd    = clear_val
-    Sfcprop%albivis_lnd    = clear_val
-    Sfcprop%albinir_lnd    = clear_val
-    Sfcprop%albdvis_ice    = clear_val
-    Sfcprop%albdnir_ice    = clear_val
-    Sfcprop%albivis_ice    = clear_val
-    Sfcprop%albinir_ice    = clear_val
-    Sfcprop%emiss      = clear_val
 
     Sfcprop%snicexy    = clear_val
     Sfcprop%snliqxy    = clear_val
@@ -6069,11 +6068,11 @@ module GFS_typedefs
       Diag%dv3dt    = zero
       Diag%dt3dt    = zero
       if (Model%qdiag3d) then
-         Diag%dq3dt    = zero
-!     Diag%upd_mf   = zero
-!     Diag%dwn_mf   = zero
-!     Diag%det_mf   = zero
-    endif
+        Diag%dq3dt    = zero
+        Diag%upd_mf   = zero
+        Diag%dwn_mf   = zero
+        Diag%det_mf   = zero
+      endif
     endif
 
 !

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -1289,6 +1289,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme .or. flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
 [albdnir_lnd]
   standard_name = surface_albedo_direct_NIR_over_land
   long_name = direct surface albedo NIR band over land
@@ -1296,6 +1297,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme .or. flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
 [albivis_lnd]
   standard_name = surface_albedo_diffuse_visible_over_land
   long_name = diffuse surface albedo visible band over land
@@ -1303,6 +1305,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme .or. flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
 [albinir_lnd]
   standard_name = surface_albedo_diffuse_NIR_over_land
   long_name = diffuse surface albedo NIR band over land
@@ -1310,6 +1313,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme .or. flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
 [albdvis_ice]
   standard_name = surface_albedo_direct_visible_over_ice
   long_name = direct surface albedo visible band over ice

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -1,7 +1,7 @@
 [ccpp-table-properties]
   name = GFS_statein_type
   type = ddt
-  dependencies =
+  dependencies = 
 
 [ccpp-arg-table]
   name = GFS_statein_type
@@ -273,7 +273,7 @@
 [ccpp-table-properties]
   name = GFS_stateout_type
   type = ddt
-  dependencies =
+  dependencies = 
 
 [ccpp-arg-table]
   name = GFS_stateout_type
@@ -454,7 +454,7 @@
 [ccpp-table-properties]
   name = GFS_sfcprop_type
   type = ddt
-  dependencies =
+  dependencies = 
 
 [ccpp-arg-table]
   name = GFS_sfcprop_type
@@ -624,6 +624,56 @@
 [snoalb]
   standard_name = upper_bound_on_max_albedo_over_deep_snow
   long_name = maximum snow albedo
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+[emis_lnd]
+  standard_name = surface_longwave_emissivity_over_land
+  long_name = surface lw emissivity in fraction over land
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+[emis_ice]
+  standard_name = surface_longwave_emissivity_over_ice
+  long_name = surface lw emissivity in fraction over ice
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+[sfalb_lnd]
+  standard_name = surface_diffused_shortwave_albedo_over_land
+  long_name = mean surface diffused sw albedo over land
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  optional = F
+[sfalb_ice]
+  standard_name = surface_diffused_shortwave_albedo_over_ice
+  long_name = mean surface diffused sw albedo over ice
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+[alb_ice]
+  standard_name =surface_snow_free_albedo_over_ice
+  long_name = surface snow-free albedo over ice
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+[alb_snow_ice]
+  standard_name =surface_snow_albedo_over_ice
+  long_name = surface snow albedo over ice
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+[sfalb_lnd_bck]
+  standard_name =surface_snow_free_albedo_over_land
+  long_name = surface snow-free albedo over ice
   units = frac
   dimensions = (horizontal_loop_extent)
   type = real
@@ -969,7 +1019,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)  
 [tvxy]
   standard_name = vegetation_temperature
   long_name = vegetation temperature
@@ -977,7 +1027,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)  
 [tgxy]
   standard_name = ground_temperature_for_noahmp
   long_name = ground temperature for noahmp
@@ -985,7 +1035,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)  
 [canicexy]
   standard_name = canopy_intercepted_ice_mass
   long_name = canopy intercepted ice mass
@@ -993,7 +1043,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)  
 [canliqxy]
   standard_name = canopy_intercepted_liquid_water
   long_name = canopy intercepted liquid water
@@ -1001,7 +1051,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)  
 [eahxy]
   standard_name = canopy_air_vapor_pressure
   long_name = canopy air vapor pressure
@@ -1009,7 +1059,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)  
 [tahxy]
   standard_name = canopy_air_temperature
   long_name = canopy air temperature
@@ -1017,7 +1067,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)  
 [cmxy]
   standard_name = surface_drag_coefficient_for_momentum_for_noahmp
   long_name = surface drag coefficient for momentum for noahmp
@@ -1025,7 +1075,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)  
 [chxy]
   standard_name = surface_drag_coefficient_for_heat_and_moisture_for_noahmp
   long_name = surface exchange coeff heat & moisture for noahmp
@@ -1033,7 +1083,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)  
 [fwetxy]
   standard_name = area_fraction_of_wet_canopy
   long_name = area fraction of canopy that is wetted/snowed
@@ -1041,7 +1091,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)  
 [sneqvoxy]
   standard_name = snow_mass_at_previous_time_step
   long_name = snow mass at previous time step
@@ -1049,7 +1099,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)  
 [alboldxy]
   standard_name = snow_albedo_at_previous_time_step
   long_name = snow albedo at previous time step
@@ -1057,7 +1107,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)  
 [qsnowxy]
   standard_name = snow_precipitation_rate_at_surface
   long_name = snow precipitation rate at surface
@@ -1065,7 +1115,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)  
 [wslakexy]
   standard_name = lake_water_storage
   long_name = lake water storage
@@ -1073,7 +1123,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)  
 [zwtxy]
   standard_name = water_table_depth
   long_name = water table depth
@@ -1081,7 +1131,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)  
 [waxy]
   standard_name = water_storage_in_aquifer
   long_name = water storage in aquifer
@@ -1089,7 +1139,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)  
 [wtxy]
   standard_name = water_storage_in_aquifer_and_saturated_soil
   long_name = water storage in aquifer and saturated soil
@@ -1097,7 +1147,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)  
 [tsnoxy]
   standard_name = snow_temperature
   long_name = snow_temperature
@@ -1105,7 +1155,7 @@
   dimensions = (horizontal_loop_extent, lower_bound_of_snow_vertical_dimension_for_land_surface_model:0)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)  
 [zsnsoxy]
   standard_name = layer_bottom_depth_from_snow_surface
   long_name = depth from the top of the snow surface at the bottom of the layer
@@ -1113,7 +1163,7 @@
   dimensions = (horizontal_loop_extent, lower_bound_of_snow_vertical_dimension_for_land_surface_model:soil_vertical_dimension_for_land_surface_model)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)  
 [snicexy]
   standard_name = snow_layer_ice
   long_name = snow layer ice
@@ -1121,7 +1171,7 @@
   dimensions = (horizontal_loop_extent, lower_bound_of_snow_vertical_dimension_for_land_surface_model:0)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)  
 [snliqxy]
   standard_name = snow_layer_liquid_water
   long_name = snow layer liquid water
@@ -1129,7 +1179,7 @@
   dimensions = (horizontal_loop_extent, lower_bound_of_snow_vertical_dimension_for_land_surface_model:0)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)  
 [lfmassxy]
   standard_name = leaf_mass
   long_name = leaf mass
@@ -1137,7 +1187,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)  
 [rtmassxy]
   standard_name = fine_root_mass
   long_name = fine root mass
@@ -1145,7 +1195,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)  
 [stmassxy]
   standard_name = stem_mass
   long_name = stem mass
@@ -1153,7 +1203,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)  
 [woodxy]
   standard_name = wood_mass
   long_name = wood mass including woody roots
@@ -1161,7 +1211,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)  
 [stblcpxy]
   standard_name = slow_soil_pool_mass_content_of_carbon
   long_name = stable carbon in deep soil
@@ -1169,7 +1219,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)  
 [fastcpxy]
   standard_name = fast_soil_pool_mass_content_of_carbon
   long_name = short-lived carbon in shallow soil
@@ -1177,10 +1227,10 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)  
 [xlaixy]
   standard_name = leaf_area_index
-  long_name = leaf area index
+  long_name = leaf area index 
   units = none
   dimensions = (horizontal_loop_extent)
   type = real
@@ -1188,12 +1238,12 @@
   active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme .or. (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme .and. flag_for_reading_leaf_area_index_from_input))
 [xsaixy]
   standard_name = stem_area_index
-  long_name = stem area index
+  long_name = stem area index 
   units = none
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)  
 [taussxy]
   standard_name = nondimensional_snow_age
   long_name = non-dimensional snow age
@@ -1201,7 +1251,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)  
 [smoiseq]
   standard_name = equilibrium_soil_water_content
   long_name = equilibrium soil water content
@@ -1209,7 +1259,7 @@
   dimensions = (horizontal_loop_extent,soil_vertical_dimension_for_land_surface_model)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)  
 [smcwtdxy]
   standard_name = soil_water_content_between_soil_bottom_and_water_table
   long_name = soil water content between the bottom of the soil and the water table
@@ -1217,7 +1267,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)  
 [deeprechxy]
   standard_name = water_table_recharge_when_deep
   long_name = recharge to or from the water table when deep
@@ -1225,7 +1275,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)  
 [rechxy]
   standard_name = water_table_recharge_when_shallow
   long_name = recharge to or from the water table when shallow
@@ -1242,38 +1292,70 @@
   type = real
   kind = kind_phys
   active = (flag_for_land_surface_scheme == flag_for_noah_wrfv4_land_surface_scheme)
-[albdvis]
-  standard_name = surface_albedo_direct_visible
-  long_name = direct surface albedo visible band
+[albdvis_lnd]
+  standard_name = surface_albedo_direct_visible_over_land
+  long_name = direct surface albedo visible band over land
   units = frac
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
-[albdnir]
-  standard_name = surface_albedo_direct_NIR
-  long_name = direct surface albedo NIR band
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme .or. flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+[albdnir_lnd]
+  standard_name = surface_albedo_direct_NIR_over_land
+  long_name = direct surface albedo NIR band over land
   units = frac
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
-[albivis]
-  standard_name = surface_albedo_diffuse_visible
-  long_name = diffuse surface albedo visible band
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme .or. flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+[albivis_lnd]
+  standard_name = surface_albedo_diffuse_visible_over_land
+  long_name = diffuse surface albedo visible band over land
   units = frac
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
-[albinir]
-  standard_name = surface_albedo_diffuse_NIR
-  long_name = diffuse surface albedo NIR band
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme .or. flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+[albinir_lnd]
+  standard_name = surface_albedo_diffuse_NIR_over_land
+  long_name = diffuse surface albedo NIR band over land
   units = frac
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme .or. flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+[albdvis_ice]
+  standard_name = surface_albedo_direct_visible_over_ice
+  long_name = direct surface albedo visible band over ice
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme .or. flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+[albdnir_ice]
+  standard_name = surface_albedo_direct_NIR_over_ice
+  long_name = direct surface albedo NIR band over ice
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme .or. flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+[albivis_ice]
+  standard_name = surface_albedo_diffuse_visible_over_ice
+  long_name = diffuse surface albedo visible band over ice
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme .or. flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+[albinir_ice]
+  standard_name = surface_albedo_diffuse_NIR_over_ice
+  long_name = diffuse surface albedo NIR band over ice
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme .or. flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
 [emiss]
   standard_name = surface_emissivity_lsm
   long_name = surface emissivity from lsm
@@ -1289,7 +1371,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme) 
 [sh2o]
   standard_name = volume_fraction_of_unfrozen_soil_moisture_for_land_surface_model
   long_name = volume fraction of unfrozen soil moisture for lsm
@@ -1297,7 +1379,7 @@
   dimensions = (horizontal_loop_extent,soil_vertical_dimension_for_land_surface_model)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme) 
 [keepsmfr]
   standard_name = volume_fraction_of_frozen_soil_moisture_for_land_surface_model
   long_name = volume fraction of frozen soil moisture for lsm
@@ -1305,7 +1387,7 @@
   dimensions = (horizontal_loop_extent,soil_vertical_dimension_for_land_surface_model)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme) 
 [smois]
   standard_name = volume_fraction_of_soil_moisture_for_land_surface_model
   long_name = volumetric fraction of soil moisture for lsm
@@ -1313,7 +1395,7 @@
   dimensions = (horizontal_loop_extent,soil_vertical_dimension_for_land_surface_model)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme) 
 [tslb]
   standard_name = soil_temperature_for_land_surface_model
   long_name = soil temperature for land surface model
@@ -1337,7 +1419,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme) 
 [qwv_surf_land]
   standard_name = water_vapor_mixing_ratio_at_surface_over_land
   long_name = water vapor mixing ratio at surface over land
@@ -1353,7 +1435,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme) 
 [flag_frsoil]
   standard_name = flag_for_frozen_soil_physics
   long_name = flag for frozen soil physics (RUC)
@@ -1361,7 +1443,7 @@
   dimensions = (horizontal_loop_extent,soil_vertical_dimension_for_land_surface_model)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme) 
 [rhofr]
   standard_name = density_of_frozen_precipitation
   long_name = density of frozen precipitation
@@ -1369,7 +1451,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme) 
 [tsnow_land]
   standard_name = snow_temperature_bottom_first_layer_over_land
   long_name = snow temperature at the bottom of the first snow layer over land
@@ -1385,7 +1467,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme) 
 [snowfallac_land]
   standard_name = total_accumulated_snowfall_over_land
   long_name = run-total snow accumulation on the ground
@@ -1401,7 +1483,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme) 
 [ustm]
   standard_name = surface_friction_velocity_drag
   long_name = friction velocity isolated for momentum only
@@ -1542,7 +1624,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)  
 [drainncprv]
   standard_name = explicit_rainfall_rate_from_previous_timestep
   long_name = explicit rainfall rate previous timestep
@@ -1550,7 +1632,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)  
 [diceprv]
   standard_name = ice_precipitation_rate_from_previous_timestep
   long_name = ice precipitation rate from previous timestep
@@ -1558,7 +1640,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)  
 [dsnowprv]
   standard_name = snow_precipitation_rate_from_previous_timestep
   long_name = snow precipitation rate from previous timestep
@@ -1566,7 +1648,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)  
 [dgraupelprv]
   standard_name = graupel_precipitation_rate_from_previous_timestep
   long_name = graupel precipitation rate from previous timestep
@@ -1574,7 +1656,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
+  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)  
 [alvsf]
   standard_name = mean_vis_albedo_with_strong_cosz_dependency
   long_name = mean vis albedo with strong cosz dependency
@@ -1608,7 +1690,7 @@
 [ccpp-table-properties]
   name = GFS_coupling_type
   type = ddt
-  dependencies =
+  dependencies = 
 
 [ccpp-arg-table]
   name = GFS_coupling_type
@@ -2034,7 +2116,7 @@
 [ulwsfcin_cpl]
   standard_name = surface_upwelling_longwave_flux_for_coupling
   long_name = surface upwelling LW flux for coupling
-  units = W m-2
+  units = W m-2 
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
@@ -2042,7 +2124,7 @@
 [dusfcin_cpl]
   standard_name = surface_x_momentum_flux_for_coupling
   long_name = sfc x momentum flux for coupling
-  units = Pa
+  units = Pa 
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
@@ -2050,7 +2132,7 @@
 [dvsfcin_cpl]
   standard_name = surface_y_momentum_flux_for_coupling
   long_name = sfc y momentum flux for coupling
-  units = Pa
+  units = Pa 
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
@@ -2208,7 +2290,7 @@
 [ccpp-table-properties]
   name = GFS_control_type
   type = ddt
-  dependencies =
+  dependencies = 
 
 [ccpp-arg-table]
   name = GFS_control_type
@@ -2529,13 +2611,13 @@
 [nsswr]
   standard_name = number_of_timesteps_between_shortwave_radiation_calls
   long_name = number of timesteps between shortwave radiation calls
-  units =
+  units = 
   dimensions = ()
   type = integer
 [nslwr]
   standard_name = number_of_timesteps_between_longwave_radiation_calls
   long_name = number of timesteps between longwave radiation calls
-  units =
+  units = 
   dimensions = ()
   type = integer
 [fhswr]
@@ -2656,7 +2738,7 @@
   type = integer
 [iovr]
   standard_name = flag_for_cloud_overlap_method_for_radiation
-  long_name = flag for cloud overlap method
+  long_name = flag for cloud overlap method 
   units = flag
   dimensions = ()
   type = integer
@@ -2720,7 +2802,7 @@
   units = none
   dimensions =  ()
   type = character
-  kind = len=128
+  kind = len=128 
 [nGases]
   standard_name = number_of_active_gases_used_by_RRTMGP
   long_name = number of gases available used by RRTMGP (Model%nGases)
@@ -2742,7 +2824,7 @@
   type = character
   kind = len=128
 [lw_file_clouds]
-  standard_name = rrtmgp_coeff_lw_cloud_optics
+  standard_name = rrtmgp_coeff_lw_cloud_optics 
   long_name = file containing coefficients for RRTMGP LW cloud optics (Model%lw_file_clouds)
   units = none
   dimensions =  ()
@@ -2760,7 +2842,7 @@
   units = count
   dimensions =  ()
   type = integer
-[sw_file_gas]
+[sw_file_gas] 
   standard_name = rrtmgp_kdistribution_sw
   long_name = file containing RRTMGP SW k-distribution (Model%sw_file_gas)
   units = none
@@ -2768,9 +2850,9 @@
   type = character
   kind = len=128
 [sw_file_clouds]
-  standard_name = rrtmgp_coeff_sw_cloud_optics
+  standard_name = rrtmgp_coeff_sw_cloud_optics 
   long_name = file containing coefficients for RRTMGP SW cloud optics (Model%sw_file_clouds)
-  units = none
+  units = none 
   dimensions =  ()
   type = character
   kind = len=128
@@ -2791,7 +2873,7 @@
   long_name = logical flag to control cloud optics scheme.
   units = flag
   dimensions = ()
-  type = logical
+  type = logical  
 [doGP_cldoptics_PADE]
   standard_name = flag_to_calc_lw_cld_optics_using_RRTMGP_PADE
   long_name = logical flag to control cloud optics scheme.
@@ -2809,7 +2891,7 @@
   long_name = logical flag to control RRTMGP LW calculation
   units = flag
   dimensions = ()
-  type = logical
+  type = logical 
 [doGP_lwscat]
   standard_name = flag_to_include_longwave_scattering_in_cloud_optics
   long_name = logical flag to control the addition of LW scattering in RRTMGP
@@ -3051,7 +3133,7 @@
 [mg_qcvar]
   standard_name = mg_cloud_water_variance
   long_name = cloud water relative variance for MG microphysics
-  units =
+  units = 
   dimensions = ()
   type = real
   kind = kind_phys
@@ -3459,9 +3541,9 @@
   dimensions = ()
   type = integer
 [spec_adv]
-  standard_name = flag_for_individual_cloud_species_advected
+  standard_name = flag_for_individual_cloud_species_advected 
   long_name = flag for individual cloud species advected
-  units = flag
+  units = flag 
   dimensions = ()
   type = logical
 [flgmin]
@@ -3698,7 +3780,7 @@
 [shcnvcw]
   standard_name = flag_shallow_convective_cloud
   long_name = flag for shallow convective cloud
-  units =
+  units = 
   dimensions = ()
   type = logical
 [redrag]
@@ -4307,14 +4389,14 @@
   standard_name =magnitude_of_perturbations_for_landperts
   long_name = magnitude of perturbations for landperts
   units = variable
-  dimensions = (number_of_land_surface_variables_perturbed)
+  dimensions = (number_of_land_surface_variables_perturbed) 
   type = real
   kind = kind_phys
 [lndp_var_list]
   standard_name = variables_to_be_perturbed_for_landperts
   long_name = variables to be perturbed for landperts
   units = none
-  dimensions =  (number_of_land_surface_variables_perturbed)
+  dimensions =  (number_of_land_surface_variables_perturbed) 
   type = character
   kind = len=3
 [ntrac]
@@ -4567,37 +4649,37 @@
 [nT2delt]
   standard_name = index_for_air_temperature_two_timesteps_back
   long_name = the index of air temperature two timesteps back in phy f3d
-  units =
+  units = 
   dimensions = ()
   type = integer
 [nTdelt]
   standard_name = index_for_air_temperature_at_previous_timestep
   long_name = the index of air temperature at previous timestep in phy f3d
-  units =
+  units = 
   dimensions = ()
   type = integer
 [nqv2delt]
   standard_name = index_for_specific_humidity_two_timesteps_back
   long_name = the index of specific humidity two timesteps back in phy f3d
-  units =
+  units = 
   dimensions = ()
   type = integer
 [nqvdelt]
   standard_name = index_for_specific_humidity_at_previous_timestep
   long_name = the index of specific humidity at previous timestep in phy f3d
-  units =
+  units = 
   dimensions = ()
   type = integer
 [nps2delt]
   standard_name = index_for_surface_air_pressure_two_timesteps_back
   long_name = the index of surface air pressure two timesteps back in phy f2d
-  units =
+  units = 
   dimensions = ()
   type = integer
 [npsdelt]
   standard_name = index_for_surface_air_pressure_at_previous_timestep
   long_name = the index of surface air pressure at previous timestep in phy f2d
-  units =
+  units = 
   dimensions = ()
   type = integer
 [ncnvwind]
@@ -4806,7 +4888,7 @@
   standard_name = gwd_opt
   long_name = flag to choose gwd scheme
   units = flag
-  dimensions = ()
+  dimensions = () 
   type = integer
 [do_mynnedmf]
   standard_name = do_mynnedmf
@@ -5051,12 +5133,12 @@
   units = flag
   dimensions = ()
   type = logical
-
+  
 ########################################################################
 [ccpp-table-properties]
   name = GFS_grid_type
   type = ddt
-  dependencies =
+  dependencies = 
 
 [ccpp-arg-table]
   name = GFS_grid_type
@@ -5284,7 +5366,7 @@
 [ccpp-table-properties]
   name = GFS_tbd_type
   type = ddt
-  dependencies =
+  dependencies = 
 
 [ccpp-arg-table]
   name = GFS_tbd_type
@@ -5780,7 +5862,7 @@
 [ccpp-table-properties]
   name = GFS_cldprop_type
   type = ddt
-  dependencies =
+  dependencies = 
 
 [ccpp-arg-table]
   name = GFS_cldprop_type
@@ -5811,7 +5893,7 @@
 [ccpp-table-properties]
   name = GFS_radtend_type
   type = ddt
-  dependencies =
+  dependencies = 
 
 [ccpp-arg-table]
   name = GFS_radtend_type
@@ -5903,7 +5985,7 @@
 [ccpp-table-properties]
   name = GFS_diag_type
   type = ddt
-  dependencies =
+  dependencies = 
 
 [ccpp-arg-table]
   name = GFS_diag_type
@@ -7363,11 +7445,12 @@
   kind = kind_phys
   active = (number_of_2d_auxiliary_arrays > 0)
 
+
 ########################################################################
 [ccpp-table-properties]
   name = GFS_interstitial_type
   type = ddt
-  dependencies =
+  dependencies = 
 
 [ccpp-arg-table]
   name = GFS_interstitial_type
@@ -10201,13 +10284,13 @@
   kind = kind_phys
 [ipsdsw0]
   standard_name = initial_permutation_seed_sw
-  long_name = initial seed for McICA SW
+  long_name = initial seed for McICA SW 
   units = none
   dimensions = ()
   type = integer
 [ipsdlw0]
   standard_name = initial_permutation_seed_lw
-  long_name = initial seed for McICA LW
+  long_name = initial seed for McICA LW 
   units = none
   dimensions = ()
   type = integer
@@ -10402,14 +10485,14 @@
   long_name = Fortran DDT containing RRTMGP optical properties
   units = DDT
   dimensions = ()
-  type = ty_optical_props_2str
+  type = ty_optical_props_2str  
   active = (flag_for_rrtmgp_radiation_scheme)
 [sw_optical_props_precip]
   standard_name = shortwave_optical_properties_for_precipitation
   long_name = Fortran DDT containing RRTMGP optical properties
   units = DDT
   dimensions = ()
-  type = ty_optical_props_2str
+  type = ty_optical_props_2str  
   active = (flag_for_rrtmgp_radiation_scheme)
 [sw_optical_props_clouds]
   standard_name = shortwave_optical_properties_for_cloudy_atmosphere
@@ -10558,7 +10641,7 @@
 [ccpp-table-properties]
   name = GFS_data_type
   type = ddt
-  dependencies =
+  dependencies = 
 
 [ccpp-arg-table]
   name = GFS_data_type
@@ -10756,7 +10839,7 @@
   units = kg kg-1
   dimensions = ()
   type = real
-  kind = kind_phys
+  kind = kind_phys  
 [con_omega]
   standard_name = angular_velocity_of_earth
   long_name = angular velocity of earth
@@ -10916,5 +10999,5 @@
   long_name = specific heat of ice at constant pressure
   units = J kg-1 K-1
   dimensions = ()
-  type = real
+  type = real 
   kind = kind_phys

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -657,20 +657,6 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-[alb_ice]
-  standard_name =surface_snow_free_albedo_over_ice
-  long_name = surface snow-free albedo over ice
-  units = frac
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
-[alb_snow_ice]
-  standard_name =surface_snow_albedo_over_ice
-  long_name = surface snow albedo over ice
-  units = frac
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
 [sfalb_lnd_bck]
   standard_name =surface_snow_free_albedo_over_land
   long_name = surface snow-free albedo over ice

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -1285,7 +1285,6 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme .or. flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
 [albdnir_lnd]
   standard_name = surface_albedo_direct_NIR_over_land
   long_name = direct surface albedo NIR band over land
@@ -1293,7 +1292,6 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme .or. flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
 [albivis_lnd]
   standard_name = surface_albedo_diffuse_visible_over_land
   long_name = diffuse surface albedo visible band over land
@@ -1301,7 +1299,6 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme .or. flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
 [albinir_lnd]
   standard_name = surface_albedo_diffuse_NIR_over_land
   long_name = diffuse surface albedo NIR band over land
@@ -1309,7 +1306,6 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme .or. flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
 [albdvis_ice]
   standard_name = surface_albedo_direct_visible_over_ice
   long_name = direct surface albedo visible band over ice
@@ -1317,7 +1313,6 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme .or. flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
 [albdnir_ice]
   standard_name = surface_albedo_direct_NIR_over_ice
   long_name = direct surface albedo NIR band over ice
@@ -1325,7 +1320,6 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme .or. flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
 [albivis_ice]
   standard_name = surface_albedo_diffuse_visible_over_ice
   long_name = diffuse surface albedo visible band over ice
@@ -1333,7 +1327,6 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme .or. flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
 [albinir_ice]
   standard_name = surface_albedo_diffuse_NIR_over_ice
   long_name = diffuse surface albedo NIR band over ice
@@ -1341,15 +1334,6 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme .or. flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
-[emiss]
-  standard_name = surface_emissivity_lsm
-  long_name = surface emissivity from lsm
-  units = frac
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
-  active = (flag_for_land_surface_scheme == flag_for_noahmp_land_surface_scheme)
 [wetness]
   standard_name = normalized_soil_wetness_for_land_surface_model
   long_name = normalized soil wetness for lsm

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -642,6 +642,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
+  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
 [sfalb_lnd]
   standard_name = surface_diffused_shortwave_albedo_over_land
   long_name = mean surface diffused sw albedo over land
@@ -650,6 +651,7 @@
   type = real
   kind = kind_phys
   optional = F
+  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
 [sfalb_ice]
   standard_name = surface_diffused_shortwave_albedo_over_ice
   long_name = mean surface diffused sw albedo over ice
@@ -657,6 +659,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
+  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
 [sfalb_lnd_bck]
   standard_name =surface_snow_free_albedo_over_land
   long_name = surface snow-free albedo over ice
@@ -664,6 +667,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
+  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
 [alvwf]
   standard_name = mean_vis_albedo_with_weak_cosz_dependency
   long_name = mean vis albedo with weak cosz dependency
@@ -1313,6 +1317,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
+  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
 [albdnir_ice]
   standard_name = surface_albedo_direct_NIR_over_ice
   long_name = direct surface albedo NIR band over ice
@@ -1320,6 +1325,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
+  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
 [albivis_ice]
   standard_name = surface_albedo_diffuse_visible_over_ice
   long_name = diffuse surface albedo visible band over ice
@@ -1327,6 +1333,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
+  active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
 [albinir_ice]
   standard_name = surface_albedo_diffuse_NIR_over_ice
   long_name = diffuse surface albedo NIR band over ice
@@ -1334,6 +1341,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
+  active = ( flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
 [wetness]
   standard_name = normalized_soil_wetness_for_land_surface_model
   long_name = normalized soil wetness for lsm

--- a/io/FV3GFS_io.F90
+++ b/io/FV3GFS_io.F90
@@ -355,7 +355,7 @@ module FV3GFS_io_mod
         temp2d(i,j,idx_opt+50) = GFS_Data(nb)%Sfcprop%albdnir_lnd(ix)
         temp2d(i,j,idx_opt+51) = GFS_Data(nb)%Sfcprop%albivis_lnd(ix)
         temp2d(i,j,idx_opt+52) = GFS_Data(nb)%Sfcprop%albinir_lnd(ix)
-        temp2d(i,j,idx_opt+53) = GFS_Data(nb)%Sfcprop%emiss(ix)
+        temp2d(i,j,idx_opt+53) = GFS_Data(nb)%Sfcprop%emis_lnd(ix)
         idx_opt = 141
        endif
 
@@ -809,11 +809,11 @@ module FV3GFS_io_mod
         sfc_name2(nvar_s2m+45) = 'smcwtdxy'
         sfc_name2(nvar_s2m+46) = 'deeprechxy'
         sfc_name2(nvar_s2m+47) = 'rechxy'
-        sfc_name2(nvar_s2m+48) = 'albdvis'
-        sfc_name2(nvar_s2m+49) = 'albdnir'
-        sfc_name2(nvar_s2m+50) = 'albivis'
-        sfc_name2(nvar_s2m+51) = 'albinir'
-        sfc_name2(nvar_s2m+52) = 'emiss'
+        sfc_name2(nvar_s2m+48) = 'albdvis_lnd'
+        sfc_name2(nvar_s2m+49) = 'albdnir_lnd'
+        sfc_name2(nvar_s2m+50) = 'albivis_lnd'
+        sfc_name2(nvar_s2m+51) = 'albinir_lnd'
+        sfc_name2(nvar_s2m+52) = 'emis_lnd'
       else if (Model%lsm == Model%lsm_ruc .and. warm_start) then
         sfc_name2(nvar_s2m+19) = 'wetness'
         sfc_name2(nvar_s2m+20) = 'clw_surf_land'
@@ -1134,11 +1134,11 @@ module FV3GFS_io_mod
           Sfcprop(nb)%smcwtdxy(ix)   = sfc_var2(i,j,nvar_s2m+45)
           Sfcprop(nb)%deeprechxy(ix) = sfc_var2(i,j,nvar_s2m+46)
           Sfcprop(nb)%rechxy(ix)     = sfc_var2(i,j,nvar_s2m+47)
-          Sfcprop(nb)%albdvis_lnd(ix)    = sfc_var2(i,j,nvar_s2m+48)
-          Sfcprop(nb)%albdnir_lnd(ix)    = sfc_var2(i,j,nvar_s2m+49)
-          Sfcprop(nb)%albivis_lnd(ix)    = sfc_var2(i,j,nvar_s2m+50)
-          Sfcprop(nb)%albinir_lnd(ix)    = sfc_var2(i,j,nvar_s2m+51)
-          Sfcprop(nb)%emiss(ix)      = sfc_var2(i,j,nvar_s2m+52)
+          Sfcprop(nb)%albdvis_lnd(ix)= sfc_var2(i,j,nvar_s2m+48)
+          Sfcprop(nb)%albdnir_lnd(ix)= sfc_var2(i,j,nvar_s2m+49)
+          Sfcprop(nb)%albivis_lnd(ix)= sfc_var2(i,j,nvar_s2m+50)
+          Sfcprop(nb)%albinir_lnd(ix)= sfc_var2(i,j,nvar_s2m+51)
+          Sfcprop(nb)%emis_lnd(ix)   = sfc_var2(i,j,nvar_s2m+52)
         endif
 
         if (Model%lsm == Model%lsm_noah .or. Model%lsm == Model%lsm_noahmp .or. Model%lsm == Model%lsm_noah_wrfv4 .or. (.not.warm_start)) then

--- a/io/FV3GFS_io.F90
+++ b/io/FV3GFS_io.F90
@@ -351,10 +351,10 @@ module FV3GFS_io_mod
         temp2d(i,j,idx_opt+46) = GFS_Data(nb)%Sfcprop%zsnsoxy(ix,2)
         temp2d(i,j,idx_opt+47) = GFS_Data(nb)%Sfcprop%zsnsoxy(ix,3)
         temp2d(i,j,idx_opt+48) = GFS_Data(nb)%Sfcprop%zsnsoxy(ix,4)
-        temp2d(i,j,idx_opt+49) = GFS_Data(nb)%Sfcprop%albdvis(ix)
-        temp2d(i,j,idx_opt+50) = GFS_Data(nb)%Sfcprop%albdnir(ix)
-        temp2d(i,j,idx_opt+51) = GFS_Data(nb)%Sfcprop%albivis(ix)
-        temp2d(i,j,idx_opt+52) = GFS_Data(nb)%Sfcprop%albinir(ix)
+        temp2d(i,j,idx_opt+49) = GFS_Data(nb)%Sfcprop%albdvis_lnd(ix)
+        temp2d(i,j,idx_opt+50) = GFS_Data(nb)%Sfcprop%albdnir_lnd(ix)
+        temp2d(i,j,idx_opt+51) = GFS_Data(nb)%Sfcprop%albivis_lnd(ix)
+        temp2d(i,j,idx_opt+52) = GFS_Data(nb)%Sfcprop%albinir_lnd(ix)
         temp2d(i,j,idx_opt+53) = GFS_Data(nb)%Sfcprop%emiss(ix)
         idx_opt = 141
        endif
@@ -1134,10 +1134,10 @@ module FV3GFS_io_mod
           Sfcprop(nb)%smcwtdxy(ix)   = sfc_var2(i,j,nvar_s2m+45)
           Sfcprop(nb)%deeprechxy(ix) = sfc_var2(i,j,nvar_s2m+46)
           Sfcprop(nb)%rechxy(ix)     = sfc_var2(i,j,nvar_s2m+47)
-          Sfcprop(nb)%albdvis(ix)    = sfc_var2(i,j,nvar_s2m+48)
-          Sfcprop(nb)%albdnir(ix)    = sfc_var2(i,j,nvar_s2m+49)
-          Sfcprop(nb)%albivis(ix)    = sfc_var2(i,j,nvar_s2m+50)
-          Sfcprop(nb)%albinir(ix)    = sfc_var2(i,j,nvar_s2m+51)
+          Sfcprop(nb)%albdvis_lnd(ix)    = sfc_var2(i,j,nvar_s2m+48)
+          Sfcprop(nb)%albdnir_lnd(ix)    = sfc_var2(i,j,nvar_s2m+49)
+          Sfcprop(nb)%albivis_lnd(ix)    = sfc_var2(i,j,nvar_s2m+50)
+          Sfcprop(nb)%albinir_lnd(ix)    = sfc_var2(i,j,nvar_s2m+51)
           Sfcprop(nb)%emiss(ix)      = sfc_var2(i,j,nvar_s2m+52)
         endif
 


### PR DESCRIPTION
## Description
This PR introduces options ialb=2 and iemis=2 for consistent use of albedo and emissivity with the LSMs. Also, changes made for fractional grid.

(Instructions: this, and all subsequent sections of text should be removed and filled in as appropriate.)
Provide a detailed description of what this PR does.  
What bug does it fix, or what feature does it add?  
Is a change of answers expected from this PR?  



### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes #<issue_number>
- fixes noaa-emc/fv3atm/issues/<issue_number>



## Testing

How were these changes tested?  
What compilers / HPCs was it tested with?  
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  
Have the ufs-weather-model regression test been run? On what platform?  
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on noaa-emc/nems/pull/<pr_number>
- waiting on noaa-emc/fv3atm/pull/<pr_number>
