### PR TITLE
Add dependency of ccpp-physics on gocart library to CMakeLists.txt

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,7 @@
 	branch = gsl/develop
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/NOAA-GSL/ccpp-physics
-	branch = gsl/develop-chem
+	#url = https://github.com/NOAA-GSL/ccpp-physics
+	#branch = gsl/develop-chem
+	url = https://github.com/climbfuji/ccpp-physics
+	branch = move_plumrise_to_gocart_repo

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,15 +127,17 @@ endif()
 add_subdirectory(ccpp)
 add_subdirectory(ccpp/data)
 add_subdirectory(ccpp/driver)
-add_dependencies(ccppphys   ccpp)
+add_dependencies(ccppphys   ccpp gocart)
 add_dependencies(ccppdata   ccpp ccppphys)
 add_dependencies(ccppdriver ccpp ccppphys ccppdata)
 add_dependencies(fv3dycore  ccppdriver ccpp ccppphys ccppdata)
 target_include_directories(fv3dycore PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/ccpp/framework/src
                                              ${CMAKE_CURRENT_BINARY_DIR}/ccpp/physics
                                              ${CMAKE_CURRENT_BINARY_DIR}/ccpp/driver)
+
 target_link_libraries(ccppphys PUBLIC sp::sp_d
-                                      w3nco::w3nco_d)
+                                      w3nco::w3nco_d
+                                      gocart)
 
 ###############################################################################
 ### stochastic_physics


### PR DESCRIPTION
## Description

This PR addsa dependency of ccpp-physics on the gocart library to `CMakeLists.txt`.

Associated PRs:

https://github.com/NOAA-GSL/ccpp-physics/pull/87
https://github.com/NOAA-GSL/fv3atm/pull/84
https://github.com/NOAA-GSL/GOCART/pull/2
https://github.com/NOAA-GSL/ufs-weather-model/pull/73

For testing, see https://github.com/NOAA-GSL/ufs-weather-model/pull/73.