### PR TITLE
Testing Flake model with HRRR and GSD_v0 suites.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,7 @@
 	branch = gsl/develop
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/NOAA-GSL/ccpp-physics
-	branch = gsl/develop
+	#url = https://github.com/NOAA-GSL/ccpp-physics
+	#branch = gsl/develop
+	url = https://github.com/tanyasmirnova/ccpp-physics
+	branch = gsl_dev_11aug21_lake

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,5 @@
 	branch = gsl/develop
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	#url = https://github.com/NOAA-GSL/ccpp-physics
-	#branch = gsl/develop
-	url = https://github.com/tanyasmirnova/ccpp-physics
-	branch = gsl_dev_11aug21_lake
+	url = https://github.com/NOAA-GSL/ccpp-physics
+	branch = gsl/develop

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -631,7 +631,7 @@
   standard_name = surface_snow_area_fraction_over_ice
   long_name = surface snow area fraction over ice
   units = frac
-  dimensions = (horizontal_dimension)
+  dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
   active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)
@@ -1460,7 +1460,7 @@
   standard_name = snow_temperature_bottom_first_layer_over_land
   long_name = snow temperature at the bottom of the first snow layer over land
   units = K
-  dimensions = (horizontal_dimension)
+  dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
   active = (flag_for_land_surface_scheme == flag_for_ruc_land_surface_scheme)

--- a/ccpp/suites/suite_FV3_GSD_v0.xml
+++ b/ccpp/suites/suite_FV3_GSD_v0.xml
@@ -46,6 +46,7 @@
       <scheme>sfc_nst</scheme>
       <scheme>sfc_nst_post</scheme>
       <scheme>lsm_ruc</scheme>
+      <scheme>flake_driver</scheme>
       <scheme>GFS_surface_loop_control_part2</scheme>
     </subcycle>
     <!-- End of surface iteration loop -->

--- a/ccpp/suites/suite_FV3_HRRR.xml
+++ b/ccpp/suites/suite_FV3_HRRR.xml
@@ -46,6 +46,7 @@
       <scheme>sfc_nst</scheme>
       <scheme>sfc_nst_post</scheme>
       <scheme>lsm_ruc</scheme>
+      <scheme>flake_driver</scheme>
       <scheme>GFS_surface_loop_control_part2</scheme>
     </subcycle>
     <!-- End of surface iteration loop -->


### PR DESCRIPTION
## Description
1. Fixes the bug with horizontal dimension of tsnow_land and sncovr_ice in GFS_typedefs.F90
2. Adds calls to flake_driver in FV3_HRRR and FV3_GSD_v0 suite for testing Flake model in global and regional models.

## Testing

See https://github.com/NOAA-GSL/ufs-weather-model/pull/99

## Dependencies

https://github.com/NOAA-GSL/fv3atm/pull/105
https://github.com/NOAA-GSL/ccpp-physics/pull/103
https://github.com/NOAA-GSL/ufs-weather-model/pull/99