### PR TITLE
bug fixes in ugwp and gsl drag suites

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,5 @@
 	branch = gsl/develop
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/NOAA-GSL/ccpp-physics
-	branch = gsl/develop
+	url = https://github.com/mdtoy/ccpp-physics
+	branch = gwd_bugfixes


### PR DESCRIPTION
## Description

This PR is associated with [PR #107](https://github.com/NOAA-GSL/ccpp-physics/pull/107) in the NOAA-GSL/ccpp-physics repository.  The ".gitmodules" was updated to point the ccpp/physics repo to the @mdtoy's fork.



### Issue(s) addressed

None.



## Testing

The changes were regression tested on Hera.  The log file is at:
/scratch1/BMC/wrfruc/mtoy/git_local/ufs-weather-model.gsl_develop/tests/RegressionTests_hera.intel.m.log

