### PR TITLE
Updates to MYNN-EDMF, part II - goes with PR for ccpp-physics

### DIFF
--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -6649,7 +6649,7 @@ module GFS_typedefs
         allocate (Diag%det_thl   (IM,Model%levs))
         allocate (Diag%det_sqv   (IM,Model%levs))
       endif
-      if (Model%bl_mynn_tkebudget .eq. .true.) then
+      if (Model%bl_mynn_tkebudget .eqv. .true.) then
         allocate (Diag%dqke      (IM,Model%levs))
         allocate (Diag%qwt       (IM,Model%levs))
         allocate (Diag%qshear    (IM,Model%levs))
@@ -6673,7 +6673,7 @@ module GFS_typedefs
         Diag%det_thl       = clear_val
         Diag%det_sqv       = clear_val
       endif
-      if (Model%bl_mynn_tkebudget .eq. .true.) then
+      if (Model%bl_mynn_tkebudget .eqv. .true.) then
         Diag%dqke          = clear_val
         Diag%qwt           = clear_val
         Diag%qshear        = clear_val

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -3359,7 +3359,7 @@ module GFS_typedefs
     logical              :: bl_mynn_tkebudget = .false.
     logical              :: bl_mynn_tkeadvect = .false.
     integer              :: bl_mynn_cloudpdf  = 2
-    integer              :: bl_mynn_mixlength = 2
+    integer              :: bl_mynn_mixlength = 1
     integer              :: bl_mynn_edmf      = 1
     integer              :: bl_mynn_edmf_mom  = 1
     integer              :: bl_mynn_edmf_tke  = 0

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -1014,19 +1014,18 @@ module GFS_typedefs
     logical              :: do_mynnedmf
     logical              :: do_mynnsfclay
     ! DH* TODO - move this to MYNN namelist section
-    integer              :: grav_settling      !< flag for initalizing fist time step
-    integer              :: bl_mynn_tkebudget  !< flag for activating TKE budget
+    logical              :: bl_mynn_tkebudget  !< flag for activating TKE budget
     logical              :: bl_mynn_tkeadvect  !< activate computation of TKE advection (not yet in use for FV3)
     integer              :: bl_mynn_cloudpdf   !< flag to determine which cloud PDF to use
     integer              :: bl_mynn_mixlength  !< flag for different version of mixing length formulation
     integer              :: bl_mynn_edmf       !< flag to activate the mass-flux scheme
     integer              :: bl_mynn_edmf_mom   !< flag to activate the transport of momentum
     integer              :: bl_mynn_edmf_tke   !< flag to activate the transport of TKE
-    integer              :: bl_mynn_edmf_part  !< flag to partitioning og the MF and ED areas
     integer              :: bl_mynn_cloudmix   !< flag to activate mixing of cloud species
     integer              :: bl_mynn_mixqt      !< flag to mix total water or individual species
     integer              :: bl_mynn_output     !< flag to initialize and write out extra 3D arrays
     integer              :: icloud_bl          !< flag for coupling sgs clouds to radiation
+    real(kind=kind_phys) :: bl_mynn_closure    !< flag to determine closure level of MYNN
     real(kind=kind_phys) :: var_ric
     real(kind=kind_phys) :: coef_ric_l
     real(kind=kind_phys) :: coef_ric_s
@@ -1616,6 +1615,11 @@ module GFS_typedefs
     integer, pointer               :: ktop_plume  (:)    => null()  !
     real (kind=kind_phys), pointer :: exch_h     (:,:)   => null()  !
     real (kind=kind_phys), pointer :: exch_m     (:,:)   => null()  !
+    real (kind=kind_phys), pointer :: dqke       (:,:)   => null()  !< timestep change of tke
+    real (kind=kind_phys), pointer :: qwt        (:,:)   => null()  !< vertical transport of tke
+    real (kind=kind_phys), pointer :: qshear     (:,:)   => null()  !< shear production of tke
+    real (kind=kind_phys), pointer :: qbuoy      (:,:)   => null()  !< buoyancy production of tke
+    real (kind=kind_phys), pointer :: qdiss      (:,:)   => null()  !< dissipation of tke
 
 ! Output - only in physics
     real (kind=kind_phys), pointer :: u10m   (:)     => null()   !< 10 meter u/v wind speed
@@ -3352,19 +3356,20 @@ module GFS_typedefs
     logical              :: do_mynnedmf       = .false.               !< flag for MYNN-EDMF
     logical              :: do_mynnsfclay     = .false.               !< flag for MYNN Surface Layer Scheme
     ! DH* TODO - move to MYNN namelist section
-    integer              :: grav_settling     = 0
-    integer              :: bl_mynn_tkebudget = 0
+    logical              :: bl_mynn_tkebudget = .false.
     logical              :: bl_mynn_tkeadvect = .false.
     integer              :: bl_mynn_cloudpdf  = 2
     integer              :: bl_mynn_mixlength = 2
-    integer              :: bl_mynn_edmf      = 0
+    integer              :: bl_mynn_edmf      = 1
     integer              :: bl_mynn_edmf_mom  = 1
     integer              :: bl_mynn_edmf_tke  = 0
-    integer              :: bl_mynn_edmf_part = 0
     integer              :: bl_mynn_cloudmix  = 1
     integer              :: bl_mynn_mixqt     = 0
     integer              :: bl_mynn_output    = 0
     integer              :: icloud_bl         = 1
+    real(kind=kind_phys) :: bl_mynn_closure   = 2.6                   !<   <= 2.5  only prognose tke
+                                                                      !<   2.5 < and < 3.0, prognose tke and q'2
+                                                                      !<   >= 3.0, prognose tke, q'2, T'2, and T'q'
     real(kind=kind_phys) :: var_ric           = 1.0
     real(kind=kind_phys) :: coef_ric_l        = 0.16
     real(kind=kind_phys) :: coef_ric_s        = 0.25
@@ -3608,8 +3613,9 @@ module GFS_typedefs
                                do_mynnedmf, do_mynnsfclay,                                  &
                                ! DH* TODO - move to MYNN namelist section
                                bl_mynn_cloudpdf, bl_mynn_edmf, bl_mynn_edmf_mom,            &
-                               bl_mynn_edmf_tke, bl_mynn_edmf_part, bl_mynn_cloudmix,       &
+                               bl_mynn_edmf_tke, bl_mynn_mixlength, bl_mynn_cloudmix,       &
                                bl_mynn_mixqt, bl_mynn_output, icloud_bl, bl_mynn_tkeadvect, &
+                               bl_mynn_closure, bl_mynn_tkebudget,                          &
                                ! *DH
                                gwd_opt, do_ugwp_v0, do_ugwp_v0_orog_only,                   &
                                do_ugwp_v0_nst_only,                                         &
@@ -4286,9 +4292,9 @@ module GFS_typedefs
     Model%bl_mynn_cloudmix  = bl_mynn_cloudmix
     Model%bl_mynn_mixqt     = bl_mynn_mixqt
     Model%bl_mynn_output    = bl_mynn_output
-    Model%bl_mynn_edmf_part = bl_mynn_edmf_part
     Model%bl_mynn_tkeadvect = bl_mynn_tkeadvect
-    Model%grav_settling     = grav_settling
+    Model%bl_mynn_closure   = bl_mynn_closure
+    Model%bl_mynn_tkebudget = bl_mynn_tkebudget
     Model%icloud_bl         = icloud_bl
     Model%var_ric           = var_ric
     Model%coef_ric_l        = coef_ric_l
@@ -6643,6 +6649,13 @@ module GFS_typedefs
         allocate (Diag%det_thl   (IM,Model%levs))
         allocate (Diag%det_sqv   (IM,Model%levs))
       endif
+      if (Model%bl_mynn_tkebudget .eq. .true.) then
+        allocate (Diag%dqke      (IM,Model%levs))
+        allocate (Diag%qwt       (IM,Model%levs))
+        allocate (Diag%qshear    (IM,Model%levs))
+        allocate (Diag%qbuoy     (IM,Model%levs))
+        allocate (Diag%qdiss     (IM,Model%levs))
+      endif
       allocate (Diag%nupdraft  (IM))
       allocate (Diag%maxmf     (IM))
       allocate (Diag%ktop_plume(IM))
@@ -6659,6 +6672,13 @@ module GFS_typedefs
         Diag%sub_sqv       = clear_val
         Diag%det_thl       = clear_val
         Diag%det_sqv       = clear_val
+      endif
+      if (Model%bl_mynn_tkebudget .eq. .true.) then
+        Diag%dqke          = clear_val
+        Diag%qwt           = clear_val
+        Diag%qshear        = clear_val
+        Diag%qbuoy         = clear_val
+        Diag%qdiss         = clear_val
       endif
       Diag%nupdraft      = 0
       Diag%maxmf         = clear_val

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -6649,7 +6649,7 @@ module GFS_typedefs
         allocate (Diag%det_thl   (IM,Model%levs))
         allocate (Diag%det_sqv   (IM,Model%levs))
       endif
-      if (Model%bl_mynn_tkebudget .eqv. .true.) then
+      if (Model%bl_mynn_tkebudget) then
         allocate (Diag%dqke      (IM,Model%levs))
         allocate (Diag%qwt       (IM,Model%levs))
         allocate (Diag%qshear    (IM,Model%levs))
@@ -6673,7 +6673,7 @@ module GFS_typedefs
         Diag%det_thl       = clear_val
         Diag%det_sqv       = clear_val
       endif
-      if (Model%bl_mynn_tkebudget .eqv. .true.) then
+      if (Model%bl_mynn_tkebudget) then
         Diag%dqke          = clear_val
         Diag%qwt           = clear_val
         Diag%qshear        = clear_val

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -5302,18 +5302,12 @@
   units = flag
   dimensions = ()
   type = logical
-[grav_settling]
-  standard_name = control_for_gravitational_settling_of_cloud_droplets
-  long_name = flag to activate gravitational setting of fog
-  units = flag
-  dimensions = ()
-  type = integer
 [bl_mynn_tkebudget]
   standard_name = control_for_tke_budget_output
   long_name = flag for activating TKE budget
   units = flag
   dimensions = ()
-  type = integer
+  type = logical
 [bl_mynn_tkeadvect]
   standard_name = flag_for_tke_advection
   long_name = flag for activating TKE advection
@@ -5350,12 +5344,6 @@
   units = flag
   dimensions = ()
   type = integer
-[bl_mynn_edmf_part]
-  standard_name = control_for_edmf_partitioning_in_mellor_yamada_nakanishi_niino_pbl_scheme
-  long_name = flag to partitioning og the MF and ED areas
-  units = flag
-  dimensions = ()
-  type = integer
 [bl_mynn_cloudmix]
   standard_name = control_for_cloud_species_mixing_in_mellor_yamada_nakanishi_niino_pbl_scheme
   long_name = flag to activate mixing of cloud species
@@ -5374,6 +5362,12 @@
   units = flag
   dimensions = ()
   type = integer
+[bl_mynn_closure]
+  standard_name = control_for_closure_level_in_mellor_yamada_nakanishi_niino_pbl_scheme
+  long_name = flag to determine the closure level for the mynn
+  units = flag
+  dimensions = ()
+  type = real
 [icloud_bl]
   standard_name = control_for_sgs_cloud_radiation_coupling_in_mellor_yamamda_nakanishi_niino_pbl_scheme
   long_name = flag for coupling sgs clouds to radiation
@@ -7232,6 +7226,46 @@
   type = real
   kind = kind_phys
   active = (flag_for_mellor_yamada_nakanishi_niino_pbl_scheme .and. (control_for_additional_diagnostics_in_mellor_yamada_nakanishi_niino_pbl_scheme .ne. 0))
+[dqke]
+  standard_name = total_time_rate_of_change_of_tke
+  long_name = total tke tendency
+  units = m2 s-3
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  active = (flag_for_mellor_yamada_nakanishi_niino_pbl_scheme .and. control_for_tke_budget_output)
+[qwt]
+  standard_name = tke_tendency_due_to_vertical_transport
+  long_name = tke tendency due to vertical transport and diffusion
+  units = m2 s-3
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  active = (flag_for_mellor_yamada_nakanishi_niino_pbl_scheme .and. control_for_tke_budget_output)
+[qshear]
+  standard_name = tke_tendency_due_to_shear
+  long_name = tke tendency due to shear
+  units = m2 s-3
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  active = (flag_for_mellor_yamada_nakanishi_niino_pbl_scheme .and. control_for_tke_budget_output)
+[qbuoy]
+  standard_name = tke_tendency_due_to_buoyancy
+  long_name = tke tendency due to buoyancy production or consumption
+  units = m2 s-3
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  active = (flag_for_mellor_yamada_nakanishi_niino_pbl_scheme .and. control_for_tke_budget_output)
+[qdiss]
+  standard_name = tke_tendency_due_to_dissipation
+  long_name = tke tendency due to the dissipation of tke
+  units = m2 s-3
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  active = (flag_for_mellor_yamada_nakanishi_niino_pbl_scheme .and. control_for_tke_budget_output)
 [nupdraft]
   standard_name = number_of_plumes
   long_name = number of plumes per grid column
@@ -9369,6 +9403,13 @@
 [save_q(:,:,index_of_cloud_ice_mixing_ratio_in_tracer_concentration_array)]
   standard_name = ice_water_mixing_ratio_save
   long_name = cloud ice water mixing ratio before entering a physics scheme
+  units = kg kg-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+[save_q(:,:,index_of_snow_mixing_ratio_in_tracer_concentration_array)]
+  standard_name = snow_mixing_ratio_save
+  long_name = cloud snow mixing ratio before entering a physics scheme
   units = kg kg-1
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real


### PR DESCRIPTION
This PR supports the MYNN-EDMF PR (part I):

- removes namelist options no longer used (bl_mynn_part and grav_settling)
- adds new namelist option (bl_mynn_closure) to regulate the closure level of the MYNN - default 2.6
- fixes a bug which did not allow switching to different mixing length options
- Adds arrays for TKE budget output when bl_mynn_tkebudget = .true.



## Testing

How were these changes tested?  **In short retros & case studies in debug mode**
What compilers / HPCs was it tested with?  **ifort**
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  
Have the ufs-weather-model regression test been run? On what platform?  
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies
This needs to go with the other MYNN PR:
https://github.com/NOAA-GSL/ccpp-physics/pull/121