### PR TITLE
Rrfs dev drag suite mods

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/NOAA-GSL/ccpp-physics
-  branch = RRFS_dev
+  url = https://github.com/mdtoy/ccpp-physics
+  branch = RRFS_dev_drag_suite_mods
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,7 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/mdtoy/ccpp-physics
+  url = https://github.com/mdtoyNOAA/ccpp-physics
   branch = RRFS_dev_drag_suite_mods
 [submodule "upp"]
   path = upp

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/mdtoyNOAA/ccpp-physics
-  branch = RRFS_dev_drag_suite_mods
+  url = https://github.com/NOAA-GSL/ccpp-physics
+  branch = RRFS_dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
## Description

This PR updates the submodule pointer in .gitmodules associated with [PR #132](https://github.com/NOAA-GSL/ccpp-physics/pull/132) of the NOAA-GSL/ccpp-physics repo.

This is an enhancement to two GSL drag suite components:  1) Small-scale gravity wave drag, and 2) Turbulent orographic form drag (TOFD).  The limits to orographic variance was eliminated and the e-folding height of the TOFD scheme is returned to it's original height of 1.5km.  The results improved 10m windspeed verification in a May 2021 retro test as shown in the attached report (*.pdf).  The enhancements are shown by "Experiment 3" in the report.

Is a change of answers expected from this PR?  Yes.




## Testing

Regression tests were performed to generate baseline files.  The tests passed on Hera (Intel and GNU compilers) and on Jet (Intel compiler).  The results are in the corresponding tests/RegressionsTests*log files.

The baseline files are on Hera at:
/scratch1/BMC/wrfruc/mtoy/stmp4/Michael.Toy/FV3_RT/REGRESSION_TEST_INTEL/
/scratch1/BMC/wrfruc/mtoy/stmp4/Michael.Toy/FV3_RT/REGRESSION_TEST_GNU/

And on Jet at:
/lfs4/BMC/wrfruc/mtoy/RT_BASELINE/Michael.Toy/FV3_RT/REGRESSION_TEST_INTEL/



[RRFS_GWD_retro_results_2021_12_03.pdf](https://github.com/NOAA-GSL/fv3atm/files/8219476/RRFS_GWD_retro_results_2021_12_03.pdf)

