### PR TITLE
Updated submodules for Bug fixes to drag_suite.F90 and GFS_surface_composites.F90

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/NOAA-GSL/ccpp-physics
-  branch = RRFS_dev
+  url = https://github.com/mdtoyNOAA/ccpp-physics
+  branch = RRFS_dev_drag_suite_sfc_composites_bugfixes
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/mdtoyNOAA/ccpp-physics
-  branch = RRFS_dev_drag_suite_sfc_composites_bugfixes
+  url = https://github.com/NOAA-GSL/ccpp-physics
+  branch = RRFS_dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
## Description

This PR updates the .gitmodules submodule to point to ccpp/physics [PR #140](https://github.com/NOAA-GSL/ccpp-physics/pull/140).
Is a change of answers expected from this PR?  Yes.



### Issue(s) addressed

None


## Testing

How were these changes tested?  
What compilers / HPCs was it tested with?  Hera:  Intel and GNU.  Jet: Intel.
Are the changes covered by regression tests? Yes. 
Have the ufs-weather-model regression test been run? On what platform?  
- Will the code updates change regression test baseline? Yes.
- Please commit the regression test log files in your ufs-weather-model branch

Baseline Reg test data on Hera at:
/scratch1/BMC/wrfruc/mtoy/stmp4/Michael.Toy/FV3_RT/REGRESSION_TEST_INTEL.2022_03_19
and
/scratch1/BMC/wrfruc/mtoy/stmp4/Michael.Toy/FV3_RT/REGRESSION_TEST_GNU.2022_03_19

Baseline Reg test data on Jet at:
/lfs4/BMC/wrfruc/mtoy/RT_BASELINE/Michael.Toy/FV3_RT/REGRESSION_TEST_INTEL.2022_03_19

## Dependencies

None.
