### PR TITLE
GWD, LSM and MYNN physics updates from RRFS_dev branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/NOAA-GSL/ccpp-physics
-  branch = gsl/develop
+  url = https://github.com/mdtoyNOAA/ccpp-physics
+  branch = gsl/develop_physics_mods_from_RRFS_dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/mdtoyNOAA/ccpp-physics
-  branch = gsl/develop_physics_mods_from_RRFS_dev
+  url = https://github.com/NOAA-GSL/ccpp-physics
+  branch = gsl/develop
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/ccpp/suites/suite_FV3_HRRR.xml
+++ b/ccpp/suites/suite_FV3_HRRR.xml
@@ -42,10 +42,8 @@
     <subcycle loop="2">
       <scheme>mynnsfc_wrapper</scheme>
       <scheme>GFS_surface_loop_control_part1</scheme>
-      <scheme>sfc_nst_pre</scheme>
-      <scheme>sfc_nst</scheme>
-      <scheme>sfc_nst_post</scheme>
       <scheme>lsm_ruc</scheme>
+      <scheme>flake_driver</scheme>
       <scheme>GFS_surface_loop_control_part2</scheme>
     </subcycle>
     <!-- End of surface iteration loop -->


### PR DESCRIPTION
## Description

This PR updates CCPP physics modules for the gravity wave drag (GWD), LSM and MYNN surface layer parameterization.  These updates are from the RRFS_dev branch.

1)  GWD — drag_suite.F90:  Removed limits on standard deviation of small-scale topography used by the small-scale GWD and turbulent orographic form drag (TOFD) schemes of the GSL drag suite.  Removed the height limitation of the TOFD scheme.

2)  LSM:

    There are a few changes in GFS_surface_composites.F90
    1. Added lat/lon to the parameter list for debugging purposes.
    2. Flag_restart is replaced with lsm_cold_start - no impact on the result.
    3. Removed snow initialization with the use of RUC LSM. In case of a cold
    start, snow on land or on ice is initialized in io/FV3GFS_io.F90. In case of
    a warm start, these variables are carried along.
    3. Corresponding changes in GFS_surface_composites.meta.

For module_sf_ruclsm.F90
   1. In computation of soil resistance to evaporation use soil moisture field capacity with factor 1. instead of 0.7. 
      This change will reduce direct evaporation from the bare soil.


  Also, the suite definition file "suite_FV3_HRRR.xml" was changed:  Replaced "sfc_nst" scheme with "flake_driver" scheme.


3)  MYNN sfc_layer — module_sf_mynn.F90:  changed "compute_flux" logical parameter from .false. to .true.


Is a change of answers expected from this PR?  Yes



### Issue(s) addressed

None



## Testing

The following RT's passed:
Hera - Intel — baseline results at:  /scratch1/BMC/wrfruc/mtoy/stmp4/Michael.Toy/FV3_RT/REGRESSION_TEST_INTEL.2022_03_25
Hera - GNU — baseline results at:  /scratch1/BMC/wrfruc/mtoy/stmp4/Michael.Toy/FV3_RT/REGRESSION_TEST_GNU.2022_03_25
Jet — Intel — baseline results at: /lfs4/BMC/wrfruc/mtoy/RT_BASELINE/Michael.Toy/FV3_RT/REGRESSION_TEST_INTEL.2022_03_25 


## Dependencies

None

Do PRs in upstream repositories need to be merged first?  No

