### PR TITLE
move some parameters in mynn surface layer to namelist options

### DIFF
--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -1044,6 +1044,10 @@ module GFS_typedefs
     integer              :: bl_mynn_output     !< flag to initialize and write out extra 3D arrays
     integer              :: icloud_bl          !< flag for coupling sgs clouds to radiation
     real(kind=kind_phys) :: bl_mynn_closure    !< flag to determine closure level of MYNN
+    logical              :: sfclay_compute_flux!< flag for thermal roughness lengths over water in mynnsfclay
+    logical              :: sfclay_compute_diag!< flag for computing surface diagnostics in mynnsfclay
+    integer              :: isftcflx           !< flag for thermal roughness lengths over water in mynnsfclay 
+    integer              :: iz0tlnd            !< flag for thermal roughness lengths over land in mynnsfclay
     real(kind=kind_phys) :: var_ric
     real(kind=kind_phys) :: coef_ric_l
     real(kind=kind_phys) :: coef_ric_s
@@ -3419,6 +3423,10 @@ module GFS_typedefs
     real(kind=kind_phys) :: bl_mynn_closure   = 2.6                   !<   <= 2.5  only prognose tke
                                                                       !<   2.5 < and < 3.0, prognose tke and q'2
                                                                       !<   >= 3.0, prognose tke, q'2, T'2, and T'q'
+    logical              :: sfclay_compute_diag = .false.
+    logical              :: sfclay_compute_flux = .false.
+    integer              :: isftcflx          = 0
+    integer              :: iz0tlnd           = 0
     real(kind=kind_phys) :: var_ric           = 1.0
     real(kind=kind_phys) :: coef_ric_l        = 0.16
     real(kind=kind_phys) :: coef_ric_s        = 0.25
@@ -3675,6 +3683,7 @@ module GFS_typedefs
                                bl_mynn_edmf_tke, bl_mynn_mixlength, bl_mynn_cloudmix,       &
                                bl_mynn_mixqt, bl_mynn_output, icloud_bl, bl_mynn_tkeadvect, &
                                bl_mynn_closure, bl_mynn_tkebudget,                          &
+                               isftcflx, iz0tlnd, sfclay_compute_flux, sfclay_compute_diag, &
                                ! *DH
                                gwd_opt, do_ugwp_v0, do_ugwp_v0_orog_only,                   &
                                do_ugwp_v0_nst_only,                                         &
@@ -4370,6 +4379,10 @@ module GFS_typedefs
     Model%bl_mynn_closure   = bl_mynn_closure
     Model%bl_mynn_tkebudget = bl_mynn_tkebudget
     Model%icloud_bl         = icloud_bl
+    Model%isftcflx          = isftcflx
+    Model%iz0tlnd           = iz0tlnd
+    Model%sfclay_compute_flux = sfclay_compute_flux
+    Model%sfclay_compute_diag = sfclay_compute_diag
     Model%var_ric           = var_ric
     Model%coef_ric_l        = coef_ric_l
     Model%coef_ric_s        = coef_ric_s
@@ -4953,8 +4966,18 @@ module GFS_typedefs
                                             ' bl_mynn_cloudpdf=',Model%bl_mynn_cloudpdf,         &
                                             ' bl_mynn_mixlength=',Model%bl_mynn_mixlength,       &
                                             ' bl_mynn_edmf=',Model%bl_mynn_edmf,                 &
-                                            ' bl_mynn_output=',Model%bl_mynn_output
+                                            ' bl_mynn_output=',Model%bl_mynn_output,             &
+                                            ' bl_mynn_closure=',Model%bl_mynn_closure
     endif
+
+    !--- mynn surface layer scheme
+    if (Model%do_mynnsfclay) then
+      if (Model%me == Model%master) print *,' MYNN surface layer scheme is used:',               &
+                                            ' isftcflx=',Model%isftcflx,                         &
+                                            ' iz0tlnd=',Model%iz0tlnd,                           &
+                                            ' sfclay_compute_diag=',Model%sfclay_compute_diag,   &
+                                            ' sfclay_compute_flux=',Model%sfclay_compute_flux
+    end if
 
 !--- set number of cloud types
     if (Model%cscnv) then

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -5526,6 +5526,30 @@
   units = flag
   dimensions = ()
   type = integer
+[isftcflx]
+  standard_name = flag_for_thermal_roughness_lengths_over_water_in_mynnsfclay
+  long_name = flag for thermal roughness lengths over water in mynnsfclay
+  units = flag
+  dimensions = ()
+  type = integer
+[iz0tlnd]
+  standard_name = flag_for_thermal_roughness_lengths_over_land_in_mynnsfclay
+  long_name = flag for thermal roughness lengths over land in mynnsfclay
+  units = flag
+  dimensions = ()
+  type = integer
+[sfclay_compute_flux]
+  standard_name = flag_for_computing_surface_scalar_fluxes_in_mynnsfclay
+  long_name = flag for computing surface scalar fluxes in mynnsfclay
+  units = flag
+  dimensions = ()
+  type = logical
+[sfclay_compute_diag]
+  standard_name = flag_for_computing_surface_diagnostics_in_mynnsfclay
+  long_name = flag for computing surface diagnostics in mynnsfclay
+  units = flag
+  dimensions = ()
+  type = logical
 [var_ric]
   standard_name = control_for_variable_bulk_richardson_number
   long_name = flag for calculating variable bulk richardson number for hurricane PBL


### PR DESCRIPTION
## Description

1. Bug fix for COARE3.5 - this option is not used by default so it will not cause a change in results.
2. Moved 4 internal parameters to namelist options:
- isftcflx (default = 0)
- iz0tlnd (default = 0)
- sfclay_compute_flux (default = .false.)
- sfclay_compute_diag (default = .false.)

## Testing

## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on noaa-emc/nems/pull/<pr_number>
- waiting on noaa-emc/fv3atm/pull/<pr_number>
