### PR TITLE
Adding SDF used in HFIP2022

### DIFF
--- a/ccpp/suites/suite_FV3_GFS_v17_p8_gf.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_gf.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<suite name="FV3_GFS_v17_p8_gf" version="1">
+  <!-- <init></init> -->
+  <group name="time_vary">
+    <subcycle loop="1">
+      <scheme>GFS_time_vary_pre</scheme>
+      <scheme>GFS_rrtmg_setup</scheme>
+      <scheme>GFS_rad_time_vary</scheme>
+      <scheme>GFS_phys_time_vary</scheme>
+    </subcycle>
+  </group>
+  <group name="radiation">
+    <subcycle loop="1">
+      <scheme>GFS_suite_interstitial_rad_reset</scheme>
+      <scheme>sgscloud_radpre</scheme>
+      <scheme>GFS_rrtmg_pre</scheme>
+      <scheme>GFS_radiation_surface</scheme>
+      <scheme>rad_sw_pre</scheme>
+      <scheme>rrtmg_sw</scheme>
+      <scheme>rrtmg_sw_post</scheme>
+      <scheme>rrtmg_lw_pre</scheme>
+      <scheme>rrtmg_lw</scheme>
+      <scheme>sgscloud_radpost</scheme>
+      <scheme>rrtmg_lw_post</scheme>
+      <scheme>GFS_rrtmg_post</scheme>
+    </subcycle>
+  </group>
+  <group name="physics">
+    <subcycle loop="1">
+      <scheme>GFS_suite_interstitial_phys_reset</scheme>
+      <scheme>GFS_suite_stateout_reset</scheme>
+      <scheme>get_prs_fv3</scheme>
+      <scheme>GFS_suite_interstitial_1</scheme>
+      <scheme>GFS_surface_generic_pre</scheme>
+      <scheme>GFS_surface_composites_pre</scheme>
+      <scheme>dcyc2t3</scheme>
+      <scheme>GFS_surface_composites_inter</scheme>
+      <scheme>GFS_suite_interstitial_2</scheme>
+    </subcycle>
+    <!-- Surface iteration loop -->
+    <subcycle loop="2">
+      <scheme>sfc_diff</scheme>
+      <scheme>GFS_surface_loop_control_part1</scheme>
+      <scheme>sfc_nst_pre</scheme>
+      <scheme>sfc_nst</scheme>
+      <scheme>sfc_nst_post</scheme>
+      <scheme>noahmpdrv</scheme>
+      <scheme>sfc_sice</scheme>
+      <scheme>GFS_surface_loop_control_part2</scheme>
+    </subcycle>
+    <!-- End of surface iteration loop -->
+    <subcycle loop="1">
+      <scheme>GFS_surface_composites_post</scheme>
+      <scheme>sfc_diag</scheme>
+      <scheme>sfc_diag_post</scheme>
+      <scheme>GFS_surface_generic_post</scheme>
+      <scheme>GFS_PBL_generic_pre</scheme>
+      <scheme>satmedmfvdifq</scheme>
+      <scheme>GFS_PBL_generic_post</scheme>
+      <scheme>GFS_GWD_generic_pre</scheme>
+      <scheme>unified_ugwp</scheme>
+      <scheme>unified_ugwp_post</scheme>
+      <scheme>GFS_GWD_generic_post</scheme>
+      <scheme>GFS_suite_stateout_update</scheme>
+      <scheme>ozphys_2015</scheme>
+      <scheme>h2ophys</scheme>
+      <scheme>get_phi_fv3</scheme>
+      <scheme>GFS_suite_interstitial_3</scheme>
+      <scheme>GFS_DCNV_generic_pre</scheme>
+      <scheme>cu_gf_driver_pre</scheme>
+      <scheme>cu_gf_driver</scheme>
+      <scheme>GFS_DCNV_generic_post</scheme>
+      <scheme>GFS_suite_interstitial_4</scheme>
+      <scheme>cnvc90</scheme>
+      <scheme>GFS_MP_generic_pre</scheme>
+      <scheme>mp_thompson_pre</scheme>
+      </subcycle>
+      <subcycle loop="1">
+        <scheme>mp_thompson</scheme>
+      </subcycle>
+        <subcycle loop="1">
+        <scheme>mp_thompson_post</scheme>
+        <scheme>GFS_MP_generic_post</scheme>
+        <scheme>cu_gf_driver_post</scheme>
+        <scheme>maximum_hourly_diagnostics</scheme>
+      </subcycle>
+  </group>
+  <group name="stochastics">
+    <subcycle loop="1">
+      <scheme>GFS_stochastics</scheme>
+      <scheme>phys_tend</scheme>
+    </subcycle>
+  </group>
+  <!-- <finalize></finalize> -->
+</suite>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_gf_mynn.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_gf_mynn.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<suite name="FV3_GFS_v17_p8_gf_mynn" version="1">
+  <!-- <init></init> -->
+  <group name="time_vary">
+    <subcycle loop="1">
+      <scheme>GFS_time_vary_pre</scheme>
+      <scheme>GFS_rrtmg_setup</scheme>
+      <scheme>GFS_rad_time_vary</scheme>
+      <scheme>GFS_phys_time_vary</scheme>
+    </subcycle>
+  </group>
+  <group name="radiation">
+    <subcycle loop="1">
+      <scheme>GFS_suite_interstitial_rad_reset</scheme>
+      <scheme>sgscloud_radpre</scheme>
+      <scheme>GFS_rrtmg_pre</scheme>
+      <scheme>GFS_radiation_surface</scheme>
+      <scheme>rad_sw_pre</scheme>
+      <scheme>rrtmg_sw</scheme>
+      <scheme>rrtmg_sw_post</scheme>
+      <scheme>rrtmg_lw_pre</scheme>
+      <scheme>rrtmg_lw</scheme>
+      <scheme>sgscloud_radpost</scheme>
+      <scheme>rrtmg_lw_post</scheme>
+      <scheme>GFS_rrtmg_post</scheme>
+    </subcycle>
+  </group>
+  <group name="physics">
+    <subcycle loop="1">
+      <scheme>GFS_suite_interstitial_phys_reset</scheme>
+      <scheme>GFS_suite_stateout_reset</scheme>
+      <scheme>get_prs_fv3</scheme>
+      <scheme>GFS_suite_interstitial_1</scheme>
+      <scheme>GFS_surface_generic_pre</scheme>
+      <scheme>GFS_surface_composites_pre</scheme>
+      <scheme>dcyc2t3</scheme>
+      <scheme>GFS_surface_composites_inter</scheme>
+      <scheme>GFS_suite_interstitial_2</scheme>
+    </subcycle>
+    <!-- Surface iteration loop -->
+    <subcycle loop="2">
+      <scheme>sfc_diff</scheme>
+      <scheme>GFS_surface_loop_control_part1</scheme>
+      <scheme>sfc_nst_pre</scheme>
+      <scheme>sfc_nst</scheme>
+      <scheme>sfc_nst_post</scheme>
+      <scheme>noahmpdrv</scheme>
+      <scheme>sfc_sice</scheme>
+      <scheme>GFS_surface_loop_control_part2</scheme>
+    </subcycle>
+    <!-- End of surface iteration loop -->
+    <subcycle loop="1">
+      <scheme>GFS_surface_composites_post</scheme>
+      <scheme>sfc_diag</scheme>
+      <scheme>sfc_diag_post</scheme>
+      <scheme>GFS_surface_generic_post</scheme>
+      <scheme>mynnedmf_wrapper</scheme>
+      <scheme>GFS_GWD_generic_pre</scheme>
+      <scheme>unified_ugwp</scheme>
+      <scheme>unified_ugwp_post</scheme>
+      <scheme>GFS_GWD_generic_post</scheme>
+      <scheme>GFS_suite_stateout_update</scheme>
+      <scheme>ozphys_2015</scheme>
+      <scheme>h2ophys</scheme>
+      <scheme>get_phi_fv3</scheme>
+      <scheme>GFS_suite_interstitial_3</scheme>
+      <scheme>GFS_DCNV_generic_pre</scheme>
+      <scheme>cu_gf_driver_pre</scheme>
+      <scheme>cu_gf_driver</scheme>
+      <scheme>GFS_DCNV_generic_post</scheme>
+      <scheme>GFS_suite_interstitial_4</scheme>
+      <scheme>cnvc90</scheme>
+      <scheme>GFS_MP_generic_pre</scheme>
+      <scheme>mp_thompson_pre</scheme>
+      </subcycle>
+      <subcycle loop="1">
+        <scheme>mp_thompson</scheme>
+      </subcycle>
+        <subcycle loop="1">
+        <scheme>mp_thompson_post</scheme>
+        <scheme>GFS_MP_generic_post</scheme>
+        <scheme>cu_gf_driver_post</scheme>
+        <scheme>maximum_hourly_diagnostics</scheme>
+      </subcycle>
+  </group>
+  <group name="stochastics">
+    <subcycle loop="1">
+      <scheme>GFS_stochastics</scheme>
+      <scheme>phys_tend</scheme>
+    </subcycle>
+  </group>
+  <!-- <finalize></finalize> -->
+</suite>

--- a/ccpp/suites/suite_FV3_GFS_v17_p8_mynn.xml
+++ b/ccpp/suites/suite_FV3_GFS_v17_p8_mynn.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<suite name="FV3_GFS_v17_p8_mynn" version="1">
+  <!-- <init></init> -->
+  <group name="time_vary">
+    <subcycle loop="1">
+      <scheme>GFS_time_vary_pre</scheme>
+      <scheme>GFS_rrtmg_setup</scheme>
+      <scheme>GFS_rad_time_vary</scheme>
+      <scheme>GFS_phys_time_vary</scheme>
+    </subcycle>
+  </group>
+  <group name="radiation">
+    <subcycle loop="1">
+      <scheme>GFS_suite_interstitial_rad_reset</scheme>
+      <scheme>sgscloud_radpre</scheme>
+      <scheme>GFS_rrtmg_pre</scheme>
+      <scheme>GFS_radiation_surface</scheme>
+      <scheme>rad_sw_pre</scheme>
+      <scheme>rrtmg_sw</scheme>
+      <scheme>rrtmg_sw_post</scheme>
+      <scheme>rrtmg_lw_pre</scheme>
+      <scheme>rrtmg_lw</scheme>
+      <scheme>sgscloud_radpost</scheme>
+      <scheme>rrtmg_lw_post</scheme>
+      <scheme>GFS_rrtmg_post</scheme>
+    </subcycle>
+  </group>
+  <group name="physics">
+    <subcycle loop="1">
+      <scheme>GFS_suite_interstitial_phys_reset</scheme>
+      <scheme>GFS_suite_stateout_reset</scheme>
+      <scheme>get_prs_fv3</scheme>
+      <scheme>GFS_suite_interstitial_1</scheme>
+      <scheme>GFS_surface_generic_pre</scheme>
+      <scheme>GFS_surface_composites_pre</scheme>
+      <scheme>dcyc2t3</scheme>
+      <scheme>GFS_surface_composites_inter</scheme>
+      <scheme>GFS_suite_interstitial_2</scheme>
+    </subcycle>
+    <!-- Surface iteration loop -->
+    <subcycle loop="2">
+      <scheme>sfc_diff</scheme>
+      <scheme>GFS_surface_loop_control_part1</scheme>
+      <scheme>sfc_nst_pre</scheme>
+      <scheme>sfc_nst</scheme>
+      <scheme>sfc_nst_post</scheme>
+      <scheme>noahmpdrv</scheme>
+      <scheme>sfc_sice</scheme>
+      <scheme>GFS_surface_loop_control_part2</scheme>
+    </subcycle>
+    <!-- End of surface iteration loop -->
+    <subcycle loop="1">
+      <scheme>GFS_surface_composites_post</scheme>
+      <scheme>sfc_diag</scheme>
+      <scheme>sfc_diag_post</scheme>
+      <scheme>GFS_surface_generic_post</scheme>
+      <!--scheme>GFS_PBL_generic_pre</scheme-->
+      <!--scheme>satmedmfvdifq</scheme-->
+      <!--scheme>GFS_PBL_generic_post</scheme-->
+      <scheme>mynnedmf_wrapper</scheme>
+      <scheme>GFS_GWD_generic_pre</scheme>
+      <scheme>unified_ugwp</scheme>
+      <scheme>unified_ugwp_post</scheme>
+      <scheme>GFS_GWD_generic_post</scheme>
+      <scheme>GFS_suite_stateout_update</scheme>
+      <scheme>ozphys_2015</scheme>
+      <scheme>h2ophys</scheme>
+      <scheme>get_phi_fv3</scheme>
+      <scheme>GFS_suite_interstitial_3</scheme>
+      <scheme>GFS_DCNV_generic_pre</scheme>
+      <scheme>samfdeepcnv</scheme>
+      <scheme>GFS_DCNV_generic_post</scheme>
+      <!--scheme>GFS_SCNV_generic_pre</scheme-->
+      <!--scheme>samfshalcnv</scheme-->
+      <!--scheme>GFS_SCNV_generic_post</scheme-->
+      <scheme>GFS_suite_interstitial_4</scheme>
+      <scheme>cnvc90</scheme>
+      <scheme>GFS_MP_generic_pre</scheme>
+      <scheme>mp_thompson_pre</scheme>
+      </subcycle>
+      <subcycle loop="1">
+        <scheme>mp_thompson</scheme>
+      </subcycle>
+        <subcycle loop="1">
+        <scheme>mp_thompson_post</scheme>
+        <scheme>GFS_MP_generic_post</scheme>
+        <scheme>maximum_hourly_diagnostics</scheme>
+      </subcycle>
+  </group>
+  <group name="stochastics">
+    <subcycle loop="1">
+      <scheme>GFS_stochastics</scheme>
+      <scheme>phys_tend</scheme>
+    </subcycle>
+  </group>
+  <!-- <finalize></finalize> -->
+</suite>


### PR DESCRIPTION

    -- Adding SDF used in HFIP2022 created by Judy: p8+gf & p8+mynn, based on suite_FV3_GFS_v17_p8;
    -- Also adding a SDF p8+gf+mynn used only in a combined regression test for all codes applied to HFIP.

@joeolson42 @hannahcbarnes