### PR TITLE
Updates GF and sgscloud_radpre for HFIP

### DIFF
--- a/ccpp/data/CCPP_typedefs.F90
+++ b/ccpp/data/CCPP_typedefs.F90
@@ -61,7 +61,6 @@ module CCPP_typedefs
     real (kind=kind_phys), pointer      :: adjvisbmu(:)       => null()  !<
     real (kind=kind_phys), pointer      :: adjvisdfu(:)       => null()  !<
     real (kind=kind_phys), pointer      :: adjvisdfd(:)       => null()  !<
-    real (kind=kind_phys), pointer      :: aerodp(:,:)        => null()  !<
     real (kind=kind_phys), pointer      :: alb1d(:)           => null()  !<
     real (kind=kind_phys), pointer      :: alpha(:,:)         => null()  !<
     real (kind=kind_phys), pointer      :: bexp1d(:)          => null()  !<
@@ -546,7 +545,6 @@ contains
     allocate (Interstitial%adjvisbmu       (IM))
     allocate (Interstitial%adjvisdfu       (IM))
     allocate (Interstitial%adjvisdfd       (IM))
-    allocate (Interstitial%aerodp          (IM,NSPC1))
     allocate (Interstitial%alb1d           (IM))
     if (.not. Model%do_RRTMGP) then
       ! RRTMGP uses its own cloud_overlap_param
@@ -1197,7 +1195,6 @@ contains
     type(GFS_control_type), intent(in) :: Model
     integer :: iGas
     !
-    Interstitial%aerodp       = clear_val
     Interstitial%alb1d        = clear_val
     if (.not. Model%do_RRTMGP) then
       Interstitial%alpha      = clear_val

--- a/ccpp/data/CCPP_typedefs.meta
+++ b/ccpp/data/CCPP_typedefs.meta
@@ -83,13 +83,6 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-[aerodp]
-  standard_name = atmosphere_optical_thickness_due_to_ambient_aerosol_particles
-  long_name = vertical integrated optical depth for various aerosol species
-  units = none
-  dimensions = (horizontal_loop_extent,number_of_species_for_aerosol_optical_depth)
-  type = real
-  kind = kind_phys
 [alb1d]
   standard_name = surface_albedo_perturbation
   long_name = surface albedo perturbation

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -18,6 +18,11 @@ module GFS_typedefs
 
    ! To ensure that these values match what's in the physics, array
    ! sizes are compared in the auto-generated physics caps in debug mode
+   ! from module_radiation_aerosols
+   integer, parameter :: NSPC    = 5
+   integer, parameter :: NSPC1   = NSPC + 1
+   ! To ensure that these values match what's in the physics, array
+   ! sizes are compared in the auto-generated physics caps in debug mode
    ! from aerclm_def
    integer, parameter, private :: ntrcaerm = 15
 
@@ -1605,6 +1610,7 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: coszen(:)    => null()  !< mean cos of zenith angle over rad call period
     real (kind=kind_phys), pointer :: tsflw (:)    => null()  !< surface air temp during lw calculation in k
     real (kind=kind_phys), pointer :: semis (:)    => null()  !< surface lw emissivity in fraction
+    real (kind=kind_phys), pointer :: aerodp (:)   => null()  
 
 !--- In/Out (???) (radiaition only)
     real (kind=kind_phys), pointer :: coszdg(:)    => null()  !< daytime mean cosz over rad call period
@@ -6364,6 +6370,7 @@ module GFS_typedefs
     allocate (Radtend%coszen (IM))
     allocate (Radtend%tsflw  (IM))
     allocate (Radtend%semis  (IM))
+    allocate (Radtend%aerodp  (IM,NSPC1))
 
     Radtend%htrsw  = clear_val
     Radtend%htrlw  = clear_val
@@ -6371,6 +6378,7 @@ module GFS_typedefs
     Radtend%coszen = clear_val
     Radtend%tsflw  = clear_val
     Radtend%semis  = clear_val
+    Radtend%aerodp  = clear_val
 
 !--- In/Out (???) (radiation only)
     allocate (Radtend%coszdg (IM))

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -1610,7 +1610,7 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: coszen(:)    => null()  !< mean cos of zenith angle over rad call period
     real (kind=kind_phys), pointer :: tsflw (:)    => null()  !< surface air temp during lw calculation in k
     real (kind=kind_phys), pointer :: semis (:)    => null()  !< surface lw emissivity in fraction
-    real (kind=kind_phys), pointer :: aerodp (:)   => null()  
+    real (kind=kind_phys), pointer :: aerodp (:,:) => null()  
 
 !--- In/Out (???) (radiaition only)
     real (kind=kind_phys), pointer :: coszdg(:)    => null()  !< daytime mean cosz over rad call period
@@ -6370,7 +6370,7 @@ module GFS_typedefs
     allocate (Radtend%coszen (IM))
     allocate (Radtend%tsflw  (IM))
     allocate (Radtend%semis  (IM))
-    allocate (Radtend%aerodp  (IM,NSPC1))
+    allocate (Radtend%aerodp (IM,NSPC1))
 
     Radtend%htrsw  = clear_val
     Radtend%htrlw  = clear_val
@@ -6378,7 +6378,7 @@ module GFS_typedefs
     Radtend%coszen = clear_val
     Radtend%tsflw  = clear_val
     Radtend%semis  = clear_val
-    Radtend%aerodp  = clear_val
+    Radtend%aerodp = clear_val
 
 !--- In/Out (???) (radiation only)
     allocate (Radtend%coszdg (IM))

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -7059,6 +7059,13 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
+[aerodp]
+  standard_name = atmosphere_optical_thickness_due_to_ambient_aerosol_particles
+  long_name = vertical integrated optical depth for various aerosol species
+  units = none
+  dimensions = (horizontal_loop_extent,number_of_species_for_aerosol_optical_depth)
+  type = real
+  kind = kind_phys
 [swhc]
   standard_name = tendency_of_air_temperature_due_to_shortwave_heating_assuming_clear_sky_on_radiation_timestep
   long_name = clear sky sw heating rates


### PR DESCRIPTION
## Description
- GF related changes 
```
- Merra2 AOD read into GF, replaces assumed globally uniform AOD. This change is more realistic. 
- Removes edtmax and edtmin
- Removes double counting in sgscloud_radpre when GF is used
- Output updraft mass flux and precipitation includes the all elements of the tri-modal precipitation desciption (small, mid, and deep can co-exist in one grid point)
- Mass factor included in pwav, pwev, and pwavh. 
- psum, psumh is removed since that variable is the same as pwav, pwavh
- Assumed precipitation efficiency is increased
- Temperature and specific humidity input into is now updated by the previous parameterizations
- -z_detr increased to 1000
```



### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes #<issue_number>
- fixes noaa-emc/fv3atm/issues/<issue_number>



## Testing

How were these changes tested?  
What compilers / HPCs was it tested with?  
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  
Have the ufs-weather-model regression test been run? On what platform?  
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on noaa-emc/nems/pull/<pr_number>
- waiting on noaa-emc/fv3atm/pull/<pr_number>
