### PR TITLE
Add a new tracer of coarsepm

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/haiqinli/ccpp-physics
-  branch = RRFS_dev_20230126
+  url = https://github.com/NOAA-GSL/ccpp-physics
+  branch = RRFS_dev
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/NOAA-GSL/ccpp-physics
-  branch = RRFS_dev
+  url = https://github.com/haiqinli/ccpp-physics
+  branch = RRFS_dev_20230126
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/ccpp/data/CCPP_typedefs.F90
+++ b/ccpp/data/CCPP_typedefs.F90
@@ -61,7 +61,7 @@ module CCPP_typedefs
     real (kind=kind_phys), pointer      :: adjvisbmu(:)       => null()  !<
     real (kind=kind_phys), pointer      :: adjvisdfu(:)       => null()  !<
     real (kind=kind_phys), pointer      :: adjvisdfd(:)       => null()  !<
-    real (kind=kind_phys), pointer      :: aerodp(:,:)        => null()  !<
+!   real (kind=kind_phys), pointer      :: aerodp(:,:)        => null()  !<
     real (kind=kind_phys), pointer      :: alb1d(:)           => null()  !<
     real (kind=kind_phys), pointer      :: alpha(:,:)         => null()  !<
     real (kind=kind_phys), pointer      :: bexp1d(:)          => null()  !<
@@ -546,7 +546,7 @@ contains
     allocate (Interstitial%adjvisbmu       (IM))
     allocate (Interstitial%adjvisdfu       (IM))
     allocate (Interstitial%adjvisdfd       (IM))
-    allocate (Interstitial%aerodp          (IM,NSPC1))
+!   allocate (Interstitial%aerodp          (IM,NSPC1))
     allocate (Interstitial%alb1d           (IM))
     if (.not. Model%do_RRTMGP) then
       ! RRTMGP uses its own cloud_overlap_param
@@ -1197,7 +1197,7 @@ contains
     type(GFS_control_type), intent(in) :: Model
     integer :: iGas
     !
-    Interstitial%aerodp       = clear_val
+!   Interstitial%aerodp       = clear_val
     Interstitial%alb1d        = clear_val
     if (.not. Model%do_RRTMGP) then
       Interstitial%alpha      = clear_val

--- a/ccpp/data/CCPP_typedefs.meta
+++ b/ccpp/data/CCPP_typedefs.meta
@@ -83,13 +83,6 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-[aerodp]
-  standard_name = atmosphere_optical_thickness_due_to_ambient_aerosol_particles
-  long_name = vertical integrated optical depth for various aerosol species
-  units = none
-  dimensions = (horizontal_loop_extent,number_of_species_for_aerosol_optical_depth)
-  type = real
-  kind = kind_phys
 [alb1d]
   standard_name = surface_albedo_perturbation
   long_name = surface albedo perturbation

--- a/ccpp/data/GFS_typedefs.F90
+++ b/ccpp/data/GFS_typedefs.F90
@@ -412,7 +412,6 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: emdust  (:)     => null()  !< instantaneous dust emission
     real (kind=kind_phys), pointer :: emseas  (:)     => null()  !< instantaneous sea salt emission
     real (kind=kind_phys), pointer :: emanoc  (:)     => null()  !< instantaneous anthro. oc emission
-    real (kind=kind_phys), pointer :: emcoarsepm (:)  => null()  !< instantaneous coarse pm emission
 
     !--- Smoke. These 3 arrays are hourly, so their dimension is imx24 (output is hourly)
     real (kind=kind_phys), pointer :: ebb_smoke_hr(:)    => null()  !< hourly smoke emission
@@ -2478,7 +2477,6 @@ module GFS_typedefs
       allocate (Sfcprop%emdust    (IM))
       allocate (Sfcprop%emseas    (IM))
       allocate (Sfcprop%emanoc    (IM))
-      allocate (Sfcprop%emcoarsepm   (IM))
       allocate (Sfcprop%ebb_smoke_hr (IM))
       allocate (Sfcprop%frp_hr    (IM))
       allocate (Sfcprop%frp_std_hr(IM))
@@ -2491,7 +2489,6 @@ module GFS_typedefs
       Sfcprop%emdust     = clear_val
       Sfcprop%emseas     = clear_val
       Sfcprop%emanoc     = clear_val
-      Sfcprop%emcoarsepm = clear_val
       Sfcprop%ebb_smoke_hr  = clear_val
       Sfcprop%frp_hr     = clear_val
       Sfcprop%frp_std_hr = clear_val

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -1867,9 +1867,25 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
+[aodtot]
+  standard_name = total_aod_from_aerosols
+  long_name = totol aod from aerosols
+  units = none
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  active = (do_smoke_coupling)
 [emdust]
   standard_name = emission_of_dust_for_smoke
   long_name = emission of dust for smoke
+  units = ug m-2 s-1
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  active = (do_smoke_coupling)
+[emcoarsepm]
+  standard_name = emission_of_coarse_pm_for_smoke
+  long_name = emission of coarse pm for smoke
   units = ug m-2 s-1
   dimensions = (horizontal_loop_extent)
   type = real
@@ -2571,7 +2587,7 @@
   standard_name = chem3d_mynn_pbl_transport
   long_name = mynn pbl transport of smoke and dust
   units = various
-  dimensions = (horizontal_loop_extent,vertical_layer_dimension,2)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension,3)
   type = real
   kind = kind_phys
   active = (do_smoke_coupling)
@@ -5449,6 +5465,12 @@
   units = index
   dimensions = ()
   type = integer
+[ntcoarsepm]
+  standard_name = index_for_coarse_pm_in_tracer_concentration_array
+  long_name = tracer index for coarse pm
+  units = index
+  dimensions = ()
+  type = integer
 [nchem]
   standard_name = number_of_chemical_species_vertically_mixed
   long_name = number of chemical vertically mixed
@@ -5613,6 +5635,13 @@
 [drydep_opt]
   standard_name = control_for_smoke_dry_deposition
   long_name = rrfs smoke dry deposition option
+  units = index
+  dimensions = ()
+  type = integer
+  active = (do_smoke_coupling)
+[coarsepm_settling]
+  standard_name = control_for_smoke_coarsepm_settling
+  long_name = rrfs smoke coarsepm settling option
   units = index
   dimensions = ()
   type = integer
@@ -7116,6 +7145,13 @@
   long_name = surface lw emissivity in fraction
   units = frac
   dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+[aerodp]
+  standard_name = atmosphere_optical_thickness_due_to_ambient_aerosol_particles
+  long_name = vertical integrated optical depth for various aerosol species
+  units = none
+  dimensions = (horizontal_loop_extent,number_of_species_for_aerosol_optical_depth)
   type = real
   kind = kind_phys
 [swhc]

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -1883,14 +1883,6 @@
   type = real
   kind = kind_phys
   active = (do_smoke_coupling)
-[emcoarsepm]
-  standard_name = emission_of_coarse_pm_for_smoke
-  long_name = emission of coarse pm for smoke
-  units = ug m-2 s-1
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
-  active = (do_smoke_coupling)
 [emseas]
   standard_name = emission_of_seas_for_smoke
   long_name = emission of seas for smoke

--- a/ccpp/data/GFS_typedefs.meta
+++ b/ccpp/data/GFS_typedefs.meta
@@ -2587,7 +2587,7 @@
   standard_name = dry_deposition_velocity_mynn_pbl_transport
   long_name = dry deposition velocity by mynn pbl transport
   units = m s-1
-  dimensions = (horizontal_loop_extent,2)
+  dimensions = (horizontal_loop_extent,3)
   type = real
   kind = kind_phys
   active = (do_smoke_coupling)

--- a/ccpp/driver/GFS_diagnostics.F90
+++ b/ccpp/driver/GFS_diagnostics.F90
@@ -3661,13 +3661,35 @@ module GFS_diagnostics
     if (Model%rrfs_sd .and. Model%ntsmoke>0) then
       idx = idx + 1
       ExtDiag(idx)%axes = 2
+      ExtDiag(idx)%name = 'aodtot'
+      ExtDiag(idx)%desc = 'total aod from aerosols'
+      ExtDiag(idx)%unit = ''
+      ExtDiag(idx)%mod_name = 'gfs_sfc'
+      allocate (ExtDiag(idx)%data(nblks))
+      do nb = 1,nblks
+        ExtDiag(idx)%data(nb)%var2 => Sfcprop(nb)%aodtot
+      enddo
+
+      idx = idx + 1
+      ExtDiag(idx)%axes = 2
       ExtDiag(idx)%name = 'emdust'
-      ExtDiag(idx)%desc = 'emission of dust for smoke'
+      ExtDiag(idx)%desc = 'emission of fine dust for smoke'
       ExtDiag(idx)%unit = 'ug m-2 s-1'
       ExtDiag(idx)%mod_name = 'gfs_sfc'
       allocate (ExtDiag(idx)%data(nblks))
       do nb = 1,nblks
         ExtDiag(idx)%data(nb)%var2 => Sfcprop(nb)%emdust
+      enddo
+
+      idx = idx + 1
+      ExtDiag(idx)%axes = 2
+      ExtDiag(idx)%name = 'emcoarsepm'
+      ExtDiag(idx)%desc = 'emission of coarse dust for smoke'
+      ExtDiag(idx)%unit = 'ug m-2 s-1'
+      ExtDiag(idx)%mod_name = 'gfs_sfc'
+      allocate (ExtDiag(idx)%data(nblks))
+      do nb = 1,nblks
+        ExtDiag(idx)%data(nb)%var2 => Sfcprop(nb)%emcoarsepm
       enddo
 
       idx = idx + 1

--- a/ccpp/driver/GFS_diagnostics.F90
+++ b/ccpp/driver/GFS_diagnostics.F90
@@ -3683,17 +3683,6 @@ module GFS_diagnostics
 
       idx = idx + 1
       ExtDiag(idx)%axes = 2
-      ExtDiag(idx)%name = 'emcoarsepm'
-      ExtDiag(idx)%desc = 'emission of coarse dust for smoke'
-      ExtDiag(idx)%unit = 'ug m-2 s-1'
-      ExtDiag(idx)%mod_name = 'gfs_sfc'
-      allocate (ExtDiag(idx)%data(nblks))
-      do nb = 1,nblks
-        ExtDiag(idx)%data(nb)%var2 => Sfcprop(nb)%emcoarsepm
-      enddo
-
-      idx = idx + 1
-      ExtDiag(idx)%axes = 2
       ExtDiag(idx)%name = 'emseas'
       ExtDiag(idx)%desc = 'emission of seas for smoke'
       ExtDiag(idx)%unit = 'ug m-2 s-1'


### PR DESCRIPTION
## Description

1. Add a new tracer of coarsepm, which is mainly from the coarse dust emission.
2. A bug fix of dust emission from Barry.
3. An update of smoke/dust direct and indirect feedback.
4. An update of plumerise.


## Testing

What compilers / HPCs was it tested with?  
Intel compiler on Hera.

Are the changes covered by regression tests? Yes.

Have the ufs-weather-model regression test been run? On what platform?  
The regression test was successful on Hera with Intel compiler.

- Will the code updates change regression test baseline? Yes, a new tracer added for the conus13km smoke case.
- Please commit the regression test log files in your ufs-weather-model branch
Yes, it was committed. (/scratch2/BMC/acomp/Haiqin.Li/Commit/RRFS_dev/coarsepm.ufs-weather-model/tests/RegressionTests_hera.intel.log)